### PR TITLE
Test addition to Python resolver

### DIFF
--- a/P220889-LID en-US.md
+++ b/P220889-LID en-US.md
@@ -1,0 +1,406 @@
+```
+P220889 – System and Method for Resilient Identification and
+Management of Hyperlinks
+```
+# TECHNICAL FIELD OF THE INVENTION
+
+# The invention relates to the field of data processing and information management, in
+
+# particular systems and methods for the stable, unambiguous, and long-term reliable
+
+# identification, management, and assignment of hyperlinks, including their source and
+
+# target resources, in a computer network.
+
+# STATE OF THE ART
+
+# Hyperlinks are the basic structure of the World Wide Web. However, conventional links
+
+# refer directly to a URL (Uniform Resource Locator). A URL specifies the storage location
+
+# of a target resource, including the host (server computer), its port (access interface), and
+
+# the file path on the host. If the target resource is deleted or its structure changes, for
+
+# example, by changing the storage location on the host, a "dead" link is created, i.e., the
+
+# computer attempting to connect to the target resource returns a 404 error.
+
+# Well-known approaches for referencing target resources are:
+
+# - URL shorteners. These only generate alternative, shortened URLs, but do not solve the
+
+# problem of reference integrity. An example of a URL shortening service is offered at bit.ly.
+
+# - DOI systems (DOI = Digital Object Identifier). These work for scientific publications,
+
+# but not for general web content or company documents.
+
+# - Blockchain or hash approaches. These only secure certain versions, but are not very
+
+# flexible in dynamic contexts.
+
+# The approaches mentioned only consider the target address of a link's target resource.
+
+# However, there is no solution that also uniquely manages the source address of the
+
+# source resource. As a result, it has not yet been possible to trace the origin and usage
+
+# context of a link in a technically resilient manner.
+
+
+## SUBJECT OF THE INVENTION
+
+# The invention provides a system, method, and computer program product for the resilient
+
+# identification and management of hyperlinks using unique LinkID technology with source
+
+# resource and target resource management and persistent identifier namespace. A
+
+# "persistent identifier namespace" is understood to be a namespace that assigns a unique
+
+# identifier in the form of a LinkID to each reference ("hyperlink" or "link") from a source
+
+# resource to a target resource. These LinkIDs form a namespace. Unless otherwise
+
+# specified in the context of the following description, the term "source resource" refers to
+
+# the storage location (address) of the digital object forming the source, and the term
+
+# "target resource" refers to the storage location of the digital object forming the target of
+
+# the reference.
+
+# The system according to the invention has the features of claim 1. Further embodiments
+
+# of the system according to the invention are the subject of the claims dependent on claim
+
+# 1. A system within the meaning of claim 1 is understood to be an arrangement of at least
+
+# two computers connected to each other, whereby this connection allows an exchange of
+
+# data between the computers. The connection may be wired or wireless. In the most
+
+# relevant applications, the at least two computers are connected in a network, which may
+
+# in particular be the Internet.
+
+# The method according to the invention has the features of claim 7. A further embodiment
+
+# of the method according to the invention is the subject of the claim dependent on claim
+
+# 7.
+
+# The computer program product according to the invention has the features of claim 8.
+
+# The invention provides a LinkID system that manages both the source resource (original
+
+# document, position, context) and the target resource (document, position, context) of a
+
+# hyperlink. Each hyperlink is uniquely identified by a LinkID. The LinkID can contain or
+
+# reference metadata about the source resource and the target resource. With the system
+
+# according to the invention, changes to source resource or target resource objects remain
+
+# traceable.
+
+# In addition, the invention introduces a "persistent identifier" that becomes a "link
+
+# identifier" ("LinkID"). Each hyperlink is thus given a unique identifier in the format:
+
+# Namespace designation:<prefixed identifier>
+
+
+# In an exemplary embodiment, the LinkID has the following format:
+
+# lid:7e96f229-21c3-4a3d-a6cf-ef7d8dd70f
+
+# where "lid" denotes the namespace created according to the invention.
+
+# The LinkID represents a prefixed identifier that never breaks. The prefix 'lid:' defines the
+
+# namespace and distinguishes the technology from conventional identification systems
+
+# (DOI = Digital Object Identifier, URN = Uniform Resource Name, URL = Uniform Resource
+
+# Locator). The suffixed identifier can be implemented as a UUID (Universally Unique
+
+# Identifier), hash, or AI-generated signature.
+
+# "Non-breaking" means that the identifier stability is guaranteed, regardless of changes to
+
+# the original target resource. Unlike classic URLs, which "break" when moved/changed
+
+# (i.e., generate 404 errors), the LinkID remains permanently valid. "Non-breaking"
+
+# therefore means persistent, stable, unchangeable, permanently resolvable. Accordingly,
+
+# the LinkID is a persistent, uniquely generated identifier that remains permanently valid
+
+# regardless of changes to the original target resource and can always be resolved to a
+
+# current target address. "Non-breaking" therefore means technical resilience against
+
+# decay.
+
+The system according to the invention may have the following features:
+
+**Role and rights management** : Specific roles (e.g., administrators, authors, publishers) can be
+defined to determine who is allowed to create or change source resource and target resource
+entries.
+
+**Offline and hybrid use:** LinkIDs can also be used in offline media (e.g., PDFs, QR codes, print)
+and resolved again when accessed online.
+
+**There are also significant advantages:** sustainability/green IT by avoiding redundant queries
+and dead links, the creation of an open or proprietary ecosystem (analogous to DOI/ISBN), and
+an architecture that is scalable to billions of links (cloud-native, distributed, with caching and
+sharding).
+
+**The technical solution also includes mechanisms for multiple destinations:**
+
+A source resource can reference different target resources (e.g., language versions, mirror
+servers, backups), and a target resource can be linked from multiple source resources.
+
+An example of the multi-destination approach is when a document with the same LinkID refers
+to different language versions. An offline example is when a LinkID embedded in a printed QR
+code reliably refers to the target resource after scanning.
+
+
+The system according to the invention comprises in particular:
+
+**1. A LinkID generator** that generates a unique LinkID based on cryptographic hashing algorithms
+and/or AI-supported context analysis.
+**2. A source registry** that stores information about the source resource (source object) of a
+hyperlink. This information may include, for example, one or more of the following: document ID,
+position in a text, context description, version. The source registry enables traceability of where
+a hyperlink was originally set.
+**3. A destination registry** that stores target resources such as web pages, files, or database
+entries and supports dynamic updating and, preferably, semantic search.
+**4. A LinkID mapping** module that maintains the relationship between the source resource and
+the target resource via the unique LinkID and preferably allows bidirectional queries, such as
+"Which source resources refer to this target resource?" and "Which target resources were linked
+from this source resource?"
+**5. A resolver module** that translates a LinkID into one or more current target resources and uses
+AI-supported semantic methods, in particular AI models and semantic search, to automatically
+redirect broken links to valid targets. The resolver module, which acts as a namespace resolver,
+recognizes and interprets the namespace prefix (e.g., "lid") and ensures that each request for a
+LinkID is translated into the correct source resource-target resource mapping.
+
+The resolver module is the component of the system that translates a requested LinkID into a
+current target resource. The basic function of the resolver module can be summarized as follows:
+
+- Input: LinkID (e.g., lid:7e96f229-21c3-4a3d-a6cf-ef7d8dd70f24).
+- Processing: Query the registry for all known target resources associated with this LinkID.
+- Output: Current, valid target resource (e.g., URL, file, archived copy).
+
+The use of AI-supported semantic processes by the resolver module can be implemented as
+follows (AI = artificial intelligence):
+
+- If the original target address of the target resource is no longer accessible (HTTP error,
+    timeout), an AI module is used.
+- This analyzes the metadata of the original target resource (title, keywords, context of the
+    document, domain structure).
+- Semantic matching algorithms (e.g., natural language processing, vector space models)
+    are used to identify alternative target resources that are equivalent or similar in content
+    to the original target resource.
+
+
+- Example 1: A scientific article has been published under a new URL. Since the target
+    resource is no longer located at the original target address under these circumstances,
+    the AI finds the same article via DOI or metadata.
+- Example 2: A company website has been restructured. In such a case, the AI can identify
+    the new page by text similarity and navigation structure.
+
+The resolver module serves to ensure that users receive a valid, semantically equivalent target
+resource despite the original target resource being unavailable. It thus prevents information loss
+and enables consistent navigation in terms of content, even with dynamic or migrated content.
+
+The invention has the following advantages:
+
+- **Holistic management** : Both the origin (source resource) and the destination (target
+    resource) are technically secured.
+- **Traceability:** Increased traceability of where links originate and how they are used.
+- **Data integrity** : Changes to source or target resources remain traceable.
+- **Resilience:** Prevents loss of information due to dead links.
+    **Scalability:** Can be used in global web and document infrastructures.
+- **Security:** Auditability through cryptographic methods and versioning.
+- **Sustainability** : Longer shelf life for digital resources.
+
+In a preferred embodiment of the system according to the invention, the source registry
+additionally stores context information and metadata such as document ID, position in the
+document, and/or author.
+
+Furthermore, it may be provided that the LinkID mapping module enables bidirectional queries
+between the source resource and the target resource.
+
+In a further embodiment of the invention, it may be provided that changes to the source resource
+or target resource are stored in a versioned and auditable manner. The system according to the
+invention may comprise an audit and recovery mechanism for this purpose. This enables changes
+to be traced and ensures that users can track the status and validity of a link over time.
+
+In a particularly preferred embodiment, the unique LinkID is formed as a persistent identifier in
+the format 'lid:<prefixed identifier>’ where the prefix "lid:" defines the namespace and the
+suffixed identifier is a non-breaking, unique identifier. The invention features a namespace
+mechanism in every configuration, which can be implemented by storing all hyperlinks as LinkIDs
+with the prefix 'lid:'. The LinkID created in this way enables unique, universal, and interoperable
+referencing.
+
+
+In a preferred embodiment, the identifier following the prefix is generated as a UUID,
+cryptographic hash, or AI-based signature. A UUID (Universally Unique Identifier) has a
+standardized 128-bit format that is generated according to known RFC standards (e.g., RFC 4122)
+and ensures unique identification worldwide, regardless of the location and time of generation. A
+cryptographic hash is a checksum generated using known hash functions (e.g., SHA-256, SHA-3)
+that provides a deterministic, collisionresistant value calculated from the metadata of the source
+resource and target resource. An AI-based signature is an identifier generated by machine
+learning or semantic analysis. To obtain this, characteristics of the content (e.g., keywords,
+context, semantic vectors) are extracted and combined into a stable identifier. An AI-based
+signature has the advantage that even if the format changes or migration occurs, the signature
+can still recognize the resource based on content similarity.
+
+## BRIEF DESCRIPTION OF THE SIGNATURES
+
+Fig. 1 shows a schematic view of the system according to the invention for the resilient
+identification and management of hyperlinks.
+
+## EXAMPLES OF IMPLEMENTATION
+
+The following describes possible applications of the system, method, and computer program
+product according to the invention.
+
+1. Application in company documents
+
+If Word or PDF files are created in an organization, they can contain LinkIDs instead of direct
+URLs. Each LinkID refers bidirectionally to the original source resource (document, context) and
+the target resource (website, file). When documents are migrated to a new archive system or
+when the target resource is changed, the reference remains functional because the LinkID is
+resolved to the current or archived target address via the registry. This means that the references
+(hyperlinks) in the Word or PDF files created by the organization remain valid even after migration.
+
+2. Web integration
+
+Inventive LinkIDs are integrated into a company website or content management system (CMS)
+instead of direct URLs. If the website structure is changed, e.g., when a subpage is moved or the
+URL structure is changed, all references (hyperlinks) remain valid. The registry stores the new
+target address of the target resource and ensures that existing hyperlinks do not become
+obsolete.
+
+3. Data archiving
+
+Digital long-term archives (e.g., in libraries, government agencies, or scientific institutions) can
+use LinkIDs according to the invention to ensure access to stored content. Even after decades,
+archived versions of documents, websites, or files can be reconstructed using the LinkID. This
+ensures the integrity and traceability of sources in the long term.
+
+
+4. API (application programming interface) integration
+
+External systems can access the Source and/or Destination Registry according to the invention
+via standardized interfaces, such as REST or GraphQL APIs. This allows source resource-target
+resource mappings to be queried in real time and integrated into third-party applications. For
+example, Testing tools, search engines, or compliance systems automatically check whether
+references (hyperlinks) are still valid and, if necessary, retrieve alternative resources.
+
+6. Enterprise content management system (ECM)
+
+If a document is stored in an enterprise content management system, such as Microsoft
+SharePoint or Adobe Experience Manager, there may be a reference (hyperlink) within that
+document that points to an external website. A LinkID is now generated for this reference by
+automatically creating a LinkID in the "lid:" namespace when the document is saved (e.g.,
+lid:7e96f229-21c3-4a3d-a6cfef7d8dd70f24). This LinkID is stored in the registry together with
+metadata, namely metadata of the source resource, such as the document ID, position in the
+document, context (paragraph/reference), and metadata of the target resource, such as the
+original URL of a target website. If the reference is later called up in the document, the LinkID is
+resolved by the system checking whether the original URL is still accessible. If the URL is not
+accessible (HTTP 404 or timeout), the resolver module falls back on alternative stored target
+resources, e.g., an archived version, a mirror server, or a semantic replacement resource
+determined by AI. Versioning and an audit trail can be provided by storing each change to the
+target resource, e.g., due to relocation of the website or change of file paths, in the destination
+registry with a timestamp. This makes it possible to trace at any time which version of a target
+resource was linked to the LinkID at what point in time. The advantage for users is that they can
+continue to activate the same link in the document, usually by clicking on it, and always reach a
+valid target resource, so that even years later, the original link between the source resource and
+the target resource can be reconstructed via the reference (hyperlink). This improves compliance
+and archiving. Finally, error messages are also reduced, if not eliminated, which is important
+because every error message is associated with a failed attempt to retrieve data and
+consequently with corresponding energy consumption, so that avoiding error messages also
+reduces energy consumption (green IT).
+
+
+## PATENT CLAIMS
+
+1. System for resilient identification and management of hyperlinks, comprising:
+- at least one client computer, which is configured is send an LinkID creation request to a server
+computer,
+- at least one server computer, comprising
+
+a) A LinkID generator that generates a unique identification number (LinkID) for a hyperlink.
+
+b) a source registry that stores information about a source resource of the hyperlink,
+
+c) a destination registry that stores information about a destination resource of the hyperlink,
+
+d) a LinkID mapping module that maintains the relationship between the source resource and the
+destination resource using LinkID,
+
+e) a resolver module that resolves the LinkID into a current destination resource, wherein the
+resolver module uses AI-supported semantic methods;
+
+wherein the server computer is configured to send the LinkID to the at least one client computer
+or to resolve an already provided LinkID into a current target resource.
+
+2. System according to claim 1, wherein the source registry additionally stores context
+information and metadata such as document ID, position in the document, or author.
+3. System according to claim 1 or 2, wherein the LinkID mapping module enables bidirectional
+queries between the source resource and the target resource.
+4. System according to any one of claims 1 to 3, wherein changes to the source resource or target
+resource are stored in a versioned and auditable manner.
+5. System according to any one of claims 1 to 4, wherein the unique LinkID is formed as a
+persistent identifier in the format 'lid:<prefixed identifier>', wherein the prefix 'lid:' defines the
+namespace and the suffixed identifier is a non-breaking, unique identifier.
+6. System according to claim 5, wherein the suffixed identifier is generated as a UUID (Universally
+Unique Identifier), cryptographic hash, or AI-based signature.
+7. A method for managing hyperlinks, comprising the steps of:
+- generating a unique LinkID, in particular by a server computer in response to a LinkID creation
+request by a client computer connected to the server computer,
+- storing the linkID with source and destination information in a registry,
+- resolving the linkID into a current destination resource,
+- providing a trace of the source resource,
+- automatically redirecting to an alternative destination resource in the event of failure of an
+original URL (Uniform Resource Locator).
+
+
+8. Method according to claim 7, wherein each hyperlink is represented by a persistent identifier
+in the format 'lid:<prefixed identifier>', which uniquely references both the source and destination
+information.
+9. Computer program product comprising instructions that, when executed by a computer, cause
+the computer to perform the following steps:
+- Generating a unique LinkID,
+- storing the LinkID with source and destination information in a registry,
+- resolving the LinkID into a current target resource,
+- Providing traceability of the source resource,
+- automatically redirecting to an alternative destination resource if the original URL (Uniform
+Resource Locator) fails.
+
+## SUMMARY
+
+The invention relates to a system for the resilient identification and management of hyperlinks.
+The system according to the invention comprises at least one client computer and at least one
+server computer. The server computer comprises a LinkID generator that generates a unique
+identification number (LinkID) for a hyperlink; a source registry that stores information about the
+source resource of a hyperlink; a destination registry that stores information about the
+destination resource of a hyperlink; a LinkID mapping module that maintains the relationship
+between source and destination by means of LinkID; and a resolver module that resolves the
+LinkID into a current destination resource, wherein the resolver module uses AI-supported
+semantic methods. The invention also relates to a method for managing hyperlinks, comprising
+the steps of: generating a unique LinkID; storing the LinkID with source and destination
+information in a registry; resolving the LinkID into a current destination resource; providing
+traceability of the source resource; automatically redirecting to an alternative resource in the
+event of failure of the original URL.
+
+
+- Fig.
+
+

--- a/resolver/java/src/test/java/org/linkgenetic/resolver/controller/HealthControllerTest.java
+++ b/resolver/java/src/test/java/org/linkgenetic/resolver/controller/HealthControllerTest.java
@@ -1,0 +1,61 @@
+package org.linkgenetic.resolver.controller;
+
+import org.junit.jupiter.api.Test;
+import org.linkgenetic.resolver.config.SecurityConfig;
+import org.linkgenetic.resolver.service.CacheService;
+import org.linkgenetic.resolver.service.RegistryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = HealthController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import(SecurityConfig.class)
+class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RegistryService registryService;
+
+    @MockBean
+    private CacheService cacheService;
+
+    @Test
+    void health_returnsUp() throws Exception {
+        mockMvc.perform(get("/health"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    @Test
+    void detailedHealth_includesSections() throws Exception {
+        when(registryService.getStats()).thenReturn(new RegistryService.RegistryStats(1L, 1L, 0L));
+        when(cacheService.getStats()).thenReturn(new CacheService.CacheStats(1L, 1L));
+
+        mockMvc.perform(get("/health/detailed"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.registry.status").value("UP"))
+            .andExpect(jsonPath("$.cache.status").value("UP"));
+    }
+
+    @Test
+    void live_and_ready_endpointsReturnOk() throws Exception {
+        when(registryService.getStats()).thenReturn(new RegistryService.RegistryStats(0L, 0L, 0L));
+        when(cacheService.getStats()).thenReturn(new CacheService.CacheStats(0L, 0L));
+
+        mockMvc.perform(get("/health/live")).andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("ALIVE"));
+
+        mockMvc.perform(get("/health/ready")).andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").exists());
+    }
+}

--- a/resolver/java/src/test/java/org/linkgenetic/resolver/controller/ResolverControllerTest.java
+++ b/resolver/java/src/test/java/org/linkgenetic/resolver/controller/ResolverControllerTest.java
@@ -1,0 +1,161 @@
+package org.linkgenetic.resolver.controller;
+
+import org.junit.jupiter.api.Test;
+import org.linkgenetic.resolver.config.SecurityConfig;
+import org.linkgenetic.resolver.model.LinkIdRecord;
+import org.linkgenetic.resolver.model.ResolutionPolicy;
+import org.linkgenetic.resolver.model.ResolutionResult;
+import org.linkgenetic.resolver.service.RegistryService;
+import org.linkgenetic.resolver.service.ResolverService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ResolverController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import(SecurityConfig.class)
+class ResolverControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ResolverService resolverService;
+
+    @MockBean
+    private RegistryService registryService;
+
+    @Test
+    void getResolve_redirectsWithHeaders() throws Exception {
+        Map<String, String> headers = Map.of("X-LinkID-Resolver", "linkid-resolver-java");
+        when(resolverService.resolve(eq("abc"), anyMap())).thenReturn(
+            new ResolutionResult.RedirectResult("https://target.example", 1.0, headers)
+        );
+
+        mockMvc.perform(get("/resolve/{id}", "abc"))
+            .andExpect(status().isFound())
+            .andExpect(header().string("Location", "https://target.example"))
+            .andExpect(header().string("Link", containsString("rel=\"canonical\"")))
+            .andExpect(header().string("X-LinkID-Resolver", "linkid-resolver-java"));
+    }
+
+    @Test
+    void getResolve_metadataReturnsJson() throws Exception {
+        LinkIdRecord rec = new LinkIdRecord("abc", "active", Instant.now(), "issuer");
+        when(resolverService.resolve(eq("abc"), anyMap())).thenReturn(
+            new ResolutionResult.MetadataResult(rec)
+        );
+
+        mockMvc.perform(get("/resolve/{id}", "abc").param("format", "metadata"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Content-Type", "application/linkid+json"))
+            .andExpect(jsonPath("$.id").value("abc"))
+            .andExpect(jsonPath("$.status").value("active"));
+    }
+
+    @Test
+    @WithMockUser
+    void postRegister_requiresAuthAndReturnsCreated() throws Exception {
+        when(registryService.register(any())).thenReturn(
+            new org.linkgenetic.resolver.model.RegistrationResponse("id", "active", Instant.now(), "https://w3id.org/linkid/id")
+        );
+
+        String body = "{\n" +
+                "  \"targetUri\": \"https://example.com\",\n" +
+                "  \"mediaType\": \"text/html\",\n" +
+                "  \"language\": \"en\",\n" +
+                "  \"issuer\": \"example.org\"\n" +
+                "}";
+
+        mockMvc.perform(post("/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").value("id"))
+            .andExpect(jsonPath("$.status").value("active"));
+    }
+
+    @Test
+    @WithMockUser
+    void putUpdate_passesIssuerFromToken() throws Exception {
+        LinkIdRecord updated = new LinkIdRecord("abc", "active", Instant.now(), "example.org");
+        when(registryService.update(eq("abc"), anyList(), eq("example.org"))).thenReturn(updated);
+
+        String body = "{\n" +
+                "  \"records\": [ { \"uri\": \"https://x\", \"status\": \"active\", \"mediaType\": \"text/html\" } ]\n" +
+                "}";
+
+        mockMvc.perform(put("/resolve/{id}", "abc")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value("abc"));
+    }
+
+    @Test
+    @WithMockUser
+    void deleteWithdraw_returnsOk() throws Exception {
+        String body = "{\n" +
+                "  \"reason\": \"obsolete\",\n" +
+                "  \"contact\": \"admin@example.org\"\n" +
+                "}";
+
+        mockMvc.perform(delete("/resolve/{id}", "abc")
+                .header("Authorization", "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("withdrawn"))
+            .andExpect(jsonPath("$.id").value("abc"));
+    }
+
+    @Test
+    void getLinkId_returnsRecord() throws Exception {
+        LinkIdRecord rec = new LinkIdRecord("abc", "active", Instant.now(), "issuer");
+        when(registryService.get("abc")).thenReturn(rec);
+
+        mockMvc.perform(get("/linkid/{id}", "abc"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value("abc"));
+    }
+
+    @Test
+    void getByIssuer_returnsList() throws Exception {
+        when(registryService.getByIssuer("issuer")).thenReturn(List.of());
+        mockMvc.perform(get("/issuer/{issuer}/linkids", "issuer"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void getStats_returnsOk() throws Exception {
+        when(registryService.getStats()).thenReturn(new RegistryService.RegistryStats(1L, 1L, 0L));
+        mockMvc.perform(get("/stats"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.total").value(1));
+    }
+
+    @Test
+    void wellKnown_returnsDiscovery() throws Exception {
+        mockMvc.perform(get("/.well-known/linkid-resolver"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Content-Type", "application/json"))
+            .andExpect(header().string("Cache-Control", containsString("max-age")))
+            .andExpect(jsonPath("$.resolver").value("LinkID Resolver Java"));
+    }
+}

--- a/resolver/java/src/test/java/org/linkgenetic/resolver/exception/GlobalExceptionHandlerTest.java
+++ b/resolver/java/src/test/java/org/linkgenetic/resolver/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,72 @@
+package org.linkgenetic.resolver.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = GlobalExceptionHandlerTest.ThrowingController.class)
+@AutoConfigureMockMvc
+@Import(GlobalExceptionHandler.class)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @RestController
+    @RequestMapping("/throw")
+    static class ThrowingController {
+        @GetMapping("/invalid")
+        public ResponseEntity<Void> invalid() { throw new InvalidLinkIdFormatException("bad"); }
+        @GetMapping("/notfound")
+        public ResponseEntity<Void> notFound() { throw new LinkIdNotFoundException("missing"); }
+        @GetMapping("/withdrawn")
+        public ResponseEntity<Void> withdrawn() { throw new LinkIdWithdrawnException("gone", null); }
+        @GetMapping("/generic")
+        public ResponseEntity<Void> generic() { throw new RuntimeException("boom"); }
+    }
+
+    @Test
+    void invalid_returns400() throws Exception {
+        mockMvc.perform(get("/throw/invalid"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error").value("Invalid LinkID Format"))
+            .andExpect(jsonPath("$.linkId").value("bad"));
+    }
+
+    @Test
+    void notFound_returns404() throws Exception {
+        mockMvc.perform(get("/throw/notfound"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").value("LinkID Not Found"))
+            .andExpect(jsonPath("$.linkId").value("missing"));
+    }
+
+    @Test
+    void withdrawn_returns410() throws Exception {
+        mockMvc.perform(get("/throw/withdrawn"))
+            .andExpect(status().isGone())
+            .andExpect(jsonPath("$.error").value("LinkID Withdrawn"))
+            .andExpect(jsonPath("$.linkId").value("gone"));
+    }
+
+    @Test
+    void generic_returns500() throws Exception {
+        mockMvc.perform(get("/throw/generic"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.error").value("Internal Server Error"));
+    }
+}

--- a/resolver/java/src/test/java/org/linkgenetic/resolver/service/CacheServiceTest.java
+++ b/resolver/java/src/test/java/org/linkgenetic/resolver/service/CacheServiceTest.java
@@ -1,0 +1,85 @@
+package org.linkgenetic.resolver.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.linkgenetic.resolver.model.LinkIdRecord;
+import org.linkgenetic.resolver.model.ResolutionResult;
+import org.linkgenetic.resolver.repository.CacheRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CacheServiceTest {
+
+    @Mock
+    private CacheRepository cacheRepository;
+
+    @InjectMocks
+    private CacheService cacheService;
+
+    @Test
+    void put_passesDuration() {
+        ResolutionResult value = new ResolutionResult.MetadataResult(new LinkIdRecord());
+        cacheService.put("k", value, 42);
+        verify(cacheRepository).put(eq("k"), eq(value), eq(Duration.ofSeconds(42)));
+    }
+
+    @Test
+    void get_hitIncrementsHitsAndReturnsValue() {
+        ResolutionResult value = new ResolutionResult.MetadataResult(new LinkIdRecord());
+        when(cacheRepository.get("k")).thenReturn(Optional.of(value));
+
+        Optional<ResolutionResult> out = cacheService.get("k");
+        assertThat(out).containsSame(value);
+        verify(cacheRepository).incrementCounter("hits");
+    }
+
+    @Test
+    void get_missIncrementsMisses() {
+        when(cacheRepository.get("k")).thenReturn(Optional.empty());
+        Optional<ResolutionResult> out = cacheService.get("k");
+        assertThat(out).isEmpty();
+        verify(cacheRepository).incrementCounter("misses");
+    }
+
+    @Test
+    void get_exceptionReturnsEmptyAndIncrementsMisses() {
+        when(cacheRepository.get("k")).thenThrow(new RuntimeException("x"));
+        Optional<ResolutionResult> out = cacheService.get("k");
+        assertThat(out).isEmpty();
+        verify(cacheRepository).incrementCounter("misses");
+    }
+
+    @Test
+    void evict_evictPattern_exists_delegates() {
+        cacheService.evict("k");
+        verify(cacheRepository).evict("k");
+
+        cacheService.evictPattern("p*");
+        verify(cacheRepository).evictPattern("p*");
+
+        when(cacheRepository.exists("k")).thenReturn(true);
+        assertThat(cacheService.exists("k")).isTrue();
+    }
+
+    @Test
+    void getStats_returnsCountersOrDefaultsOnError() {
+        when(cacheRepository.getCounter("hits")).thenReturn(5L);
+        when(cacheRepository.getCounter("misses")).thenReturn(5L);
+        CacheService.CacheStats stats = cacheService.getStats();
+        assertThat(stats.getTotal()).isEqualTo(10L);
+        assertThat(stats.getHitRate()).isEqualTo(0.5);
+
+        when(cacheRepository.getCounter(anyString())).thenThrow(new RuntimeException());
+        CacheService.CacheStats stats2 = cacheService.getStats();
+        assertThat(stats2.getTotal()).isEqualTo(0L);
+    }
+}

--- a/resolver/java/src/test/java/org/linkgenetic/resolver/service/RegistryServiceTest.java
+++ b/resolver/java/src/test/java/org/linkgenetic/resolver/service/RegistryServiceTest.java
@@ -1,0 +1,156 @@
+package org.linkgenetic.resolver.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.linkgenetic.resolver.exception.LinkIdNotFoundException;
+import org.linkgenetic.resolver.model.*;
+import org.linkgenetic.resolver.repository.LinkIdRepository;
+import org.linkgenetic.resolver.util.LinkIdGenerator;
+import org.linkgenetic.resolver.util.LinkIdValidator;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RegistryServiceTest {
+
+    @Mock
+    private LinkIdRepository repository;
+
+    @Mock
+    private LinkIdGenerator generator;
+
+    @Mock
+    private LinkIdValidator validator;
+
+    @Mock
+    private CacheService cacheService;
+
+    @InjectMocks
+    private RegistryService registryService;
+
+    private RegistrationRequest request;
+
+    @BeforeEach
+    void setup() {
+        request = new RegistrationRequest();
+        request.setTargetUri("https://example.com");
+        request.setMediaType("text/html");
+        request.setLanguage("en");
+        request.setIssuer("issuer.example");
+        Map<String, Object> md = new HashMap<>();
+        md.put("k", "v");
+        request.setMetadata(md);
+    }
+
+    @Test
+    void register_persistsRecordWithDefaults() {
+        when(generator.generateUUID()).thenReturn("idididididididididididididididid");
+
+        RegistrationResponse resp = registryService.register(request);
+
+        assertThat(resp.getId()).isEqualTo("idididididididididididididididid");
+        assertThat(resp.getStatus()).isEqualTo("active");
+        assertThat(resp.getResolverUri()).contains("/" + resp.getId());
+
+        ArgumentCaptor<LinkIdRecord> captor = ArgumentCaptor.forClass(LinkIdRecord.class);
+        verify(repository).save(captor.capture());
+        LinkIdRecord saved = captor.getValue();
+        assertThat(saved.getPolicy()).isNotNull();
+        assertThat(saved.getPolicy().getCacheTTL()).isEqualTo(3600);
+        assertThat(saved.getRecords()).hasSize(1);
+        assertThat(saved.getRecords().get(0).getUri()).isEqualTo("https://example.com");
+        assertThat(saved.getRecords().get(0).getMediaType()).isEqualTo("text/html");
+        assertThat(saved.getRecords().get(0).getLanguage()).isEqualTo("en");
+        assertThat(saved.getIssuer()).isEqualTo("issuer.example");
+        assertThat(saved.getMetadata()).isNull(); // metadata is set on record, not top-level
+        assertThat(saved.getRecords().get(0).getMetadata()).containsEntry("k", "v");
+    }
+
+    @Test
+    void update_checksIssuer_updatesAndEvictsCache() {
+        when(validator.normalize("ID")).thenReturn("id");
+        LinkIdRecord existing = new LinkIdRecord("id", "active", Instant.now(), "issuer.example");
+        existing.setRecords(new ArrayList<>());
+        when(repository.findByIdAndStatus("id", "active")).thenReturn(Optional.of(existing));
+
+        List<ResolutionRecord> newRecords = List.of(new ResolutionRecord("https://new", "active", "text/html"));
+
+        LinkIdRecord updated = registryService.update("ID", newRecords, "issuer.example");
+
+        assertThat(updated.getRecords()).hasSize(1);
+        verify(cacheService).evictPattern("id*");
+        verify(repository).save(existing);
+    }
+
+    @Test
+    void update_wrongIssuer_throwsSecurityException() {
+        when(validator.normalize("ID")).thenReturn("id");
+        LinkIdRecord existing = new LinkIdRecord("id", "active", Instant.now(), "issuer.example");
+        when(repository.findByIdAndStatus("id", "active")).thenReturn(Optional.of(existing));
+
+        assertThrows(SecurityException.class, () -> registryService.update("ID", List.of(), "other.issuer"));
+    }
+
+    @Test
+    void withdraw_setsWithdrawnAndEvicts() {
+        when(validator.normalize("ID")).thenReturn("id");
+        LinkIdRecord existing = new LinkIdRecord("id", "active", Instant.now(), "issuer.example");
+        when(repository.findByIdAndStatus("id", "active")).thenReturn(Optional.of(existing));
+
+        registryService.withdraw("ID", "reason", "contact", "issuer.example");
+
+        assertThat(existing.getStatus()).isEqualTo("withdrawn");
+        assertThat(existing.getTombstone()).isNotNull();
+        verify(cacheService).evictPattern("id*");
+        verify(repository).save(existing);
+    }
+
+    @Test
+    void get_validatesAndReturns() {
+        when(validator.normalize("ID")).thenReturn("id");
+        LinkIdRecord existing = new LinkIdRecord("id", "active", Instant.now(), "issuer");
+        when(repository.findById("id")).thenReturn(Optional.of(existing));
+
+        LinkIdRecord out = registryService.get("ID");
+        assertThat(out).isSameAs(existing);
+    }
+
+    @Test
+    void get_missing_throwsNotFound() {
+        when(validator.normalize("ID")).thenReturn("id");
+        when(repository.findById("id")).thenReturn(Optional.empty());
+        assertThrows(LinkIdNotFoundException.class, () -> registryService.get("ID"));
+    }
+
+    @Test
+    void exists_returnsFalseForInvalid_thenTrueForValid() {
+        when(validator.isValid("bad")).thenReturn(false);
+        assertThat(registryService.exists("bad")).isFalse();
+
+        when(validator.isValid("GOOD")).thenReturn(true);
+        when(validator.normalize("GOOD")).thenReturn("good");
+        when(repository.existsById("good")).thenReturn(true);
+        assertThat(registryService.exists("GOOD")).isTrue();
+    }
+
+    @Test
+    void getStats_aggregatesCounts() {
+        when(repository.countByStatus("active")).thenReturn(10L);
+        when(repository.countByStatus("withdrawn")).thenReturn(2L);
+        RegistryService.RegistryStats stats = registryService.getStats();
+        assertThat(stats.getTotal()).isEqualTo(12L);
+        assertThat(stats.getActive()).isEqualTo(10L);
+        assertThat(stats.getWithdrawn()).isEqualTo(2L);
+    }
+}

--- a/resolver/java/src/test/java/org/linkgenetic/resolver/service/ResolverServiceTest.java
+++ b/resolver/java/src/test/java/org/linkgenetic/resolver/service/ResolverServiceTest.java
@@ -1,0 +1,143 @@
+package org.linkgenetic.resolver.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.linkgenetic.resolver.exception.InvalidLinkIdFormatException;
+import org.linkgenetic.resolver.exception.LinkIdNotFoundException;
+import org.linkgenetic.resolver.model.LinkIdRecord;
+import org.linkgenetic.resolver.model.ResolutionPolicy;
+import org.linkgenetic.resolver.model.ResolutionRecord;
+import org.linkgenetic.resolver.model.ResolutionResult;
+import org.linkgenetic.resolver.repository.LinkIdRepository;
+import org.linkgenetic.resolver.util.LinkIdValidator;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ResolverServiceTest {
+
+    @Mock
+    private LinkIdRepository linkIdRepository;
+
+    @Mock
+    private CacheService cacheService;
+
+    @Mock
+    private LinkIdValidator validator;
+
+    @InjectMocks
+    private ResolverService resolverService;
+
+    private LinkIdRecord activeRecord;
+
+    @BeforeEach
+    void setUp() {
+        activeRecord = new LinkIdRecord();
+        activeRecord.setId("id");
+        activeRecord.setStatus("active");
+        activeRecord.setCreated(Instant.now());
+
+        ResolutionPolicy policy = new ResolutionPolicy();
+        policy.setCacheTTL(1234);
+        activeRecord.setPolicy(policy);
+    }
+
+    @Test
+    void cacheHit_shortCircuits() {
+        when(validator.normalize("ID")).thenReturn("id");
+        when(cacheService.get(anyString())).thenReturn(Optional.of(new ResolutionResult.MetadataResult(new LinkIdRecord())));
+
+        ResolutionResult out = resolverService.resolve("ID", Map.of("format", "text/html"));
+
+        assertThat(out.getType()).isEqualTo(ResolutionResult.Type.METADATA);
+        verifyNoInteractions(linkIdRepository);
+    }
+
+    @Test
+    void resolve_happyPath_redirects_andCachesWithPolicyTTL() {
+        when(validator.normalize("id")).thenReturn("id");
+
+        ResolutionRecord r1 = new ResolutionRecord("https://a.example", "active", "text/html");
+        r1.setLanguage("en");
+        r1.setQuality(0.8);
+        r1.setValidFrom(Instant.now().minusSeconds(3600));
+        r1.setLastModified(Instant.now().minusSeconds(100));
+
+        ResolutionRecord r2 = new ResolutionRecord("https://b.example", "active", "text/html");
+        r2.setLanguage("en");
+        r2.setQuality(0.9); // better
+        r2.setValidFrom(Instant.now().minusSeconds(3600));
+        r2.setLastModified(Instant.now());
+
+        activeRecord.setRecords(List.of(r1, r2));
+
+        when(linkIdRepository.findByIdAndStatus("id", "active")).thenReturn(Optional.of(activeRecord));
+        when(cacheService.get(anyString())).thenReturn(Optional.empty());
+
+        Map<String, String> params = new HashMap<>();
+        params.put("lang", "en");
+        params.put("format", "text/html");
+
+        ResolutionResult result = resolverService.resolve("id", params);
+        assertThat(result).isInstanceOf(ResolutionResult.RedirectResult.class);
+        ResolutionResult.RedirectResult redirect = (ResolutionResult.RedirectResult) result;
+        assertThat(redirect.getUri()).isEqualTo("https://b.example");
+        assertThat(redirect.getHeaders()).containsEntry("Cache-Control", "max-age=1234");
+
+        verify(cacheService).put(anyString(), eq(result), eq(1234));
+    }
+
+    @Test
+    void resolve_metadataFormat_returnsMetadataResult() {
+        when(validator.normalize("id")).thenReturn("id");
+        activeRecord.setRecords(Collections.emptyList());
+        when(linkIdRepository.findByIdAndStatus("id", "active")).thenReturn(Optional.of(activeRecord));
+        when(cacheService.get(anyString())).thenReturn(Optional.empty());
+
+        Map<String, String> params = Map.of("format", "metadata");
+
+        assertThrows(LinkIdNotFoundException.class, () -> resolverService.resolve("id", params));
+        // No records → not found, even if metadata requested
+    }
+
+    @Test
+    void resolve_invalidId_throwsInvalidFormat() {
+        doThrow(new InvalidLinkIdFormatException("bad"))
+                .when(validator).validate("bad");
+        assertThrows(InvalidLinkIdFormatException.class, () -> resolverService.resolve("bad", Map.of()));
+        verifyNoInteractions(linkIdRepository);
+    }
+
+    @Test
+    void generateCacheKey_sortsParamsDeterministically() {
+        when(validator.normalize("id")).thenReturn("id");
+        ResolutionRecord r = new ResolutionRecord("https://x", "active", "text/html");
+        r.setLanguage("en");
+        activeRecord.setRecords(List.of(r));
+        when(linkIdRepository.findByIdAndStatus("id", "active")).thenReturn(Optional.of(activeRecord));
+        when(cacheService.get(anyString())).thenReturn(Optional.empty());
+
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("lang", "en");
+        params.put("format", "text/html");
+
+        resolverService.resolve("id", params);
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(cacheService).put(keyCaptor.capture(), any(), any());
+        String key = keyCaptor.getValue();
+        // Expect sorted by key: format;lang
+        assertThat(key).isEqualTo("id:format=text/html;lang=en;");
+    }
+}

--- a/resolver/java/src/test/java/org/linkgenetic/resolver/util/LinkIdValidatorTest.java
+++ b/resolver/java/src/test/java/org/linkgenetic/resolver/util/LinkIdValidatorTest.java
@@ -1,0 +1,55 @@
+package org.linkgenetic.resolver.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LinkIdValidatorTest {
+
+    private final LinkIdValidator validator = new LinkIdValidator();
+
+    @Test
+    void isValid_accepts32To64Alphanumeric() {
+        String id32 = "a".repeat(32);
+        String id64 = "b".repeat(64);
+        assertThat(validator.isValid(id32)).isTrue();
+        assertThat(validator.isValid(id64)).isTrue();
+    }
+
+    @Test
+    void isValid_rejectsOutsideBoundsAndNonAlnum() {
+        assertThat(validator.isValid(null)).isFalse();
+        assertThat(validator.isValid("")).isFalse();
+        assertThat(validator.isValid("abc")).isFalse();
+        assertThat(validator.isValid("c".repeat(65))).isFalse();
+        assertThat(validator.isValid("abc-" + "d".repeat(30))).isFalse();
+    }
+
+    @Test
+    void normalize_trimsAndLowercases() {
+        assertThat(validator.normalize("  ABCDEF  ")).isEqualTo("abcdef");
+        assertThat(validator.normalize(null)).isNull();
+    }
+
+    @Test
+    void isUUID_trueFor32Hex() {
+        String uuidLike = "0123456789abcdef0123456789abcdef"; // 32 hex
+        assertThat(validator.isUUID(uuidLike)).isTrue();
+        assertThat(validator.isUUID(uuidLike.toUpperCase())).isTrue();
+    }
+
+    @Test
+    void isHash_trueFor32or64Hex() {
+        String h32 = "0".repeat(32);
+        String h64 = "a".repeat(64);
+        assertThat(validator.isHash(h32)).isTrue();
+        assertThat(validator.isHash(h64)).isTrue();
+        assertThat(validator.isHash("z".repeat(32))).isFalse();
+    }
+
+    @Test
+    void validate_throwsOnInvalid() {
+        assertThrows(RuntimeException.class, () -> validator.validate("bad"));
+    }
+}

--- a/resolver/python/tests/conftest.py
+++ b/resolver/python/tests/conftest.py
@@ -1,0 +1,199 @@
+import sys
+import types
+from typing import Any, Dict, Optional
+
+import pytest
+
+
+def _install_stub_modules():
+    """Install stub modules for services, models, and config before importing main.
+
+    The production repo doesn't ship Python implementations for these, so we
+    provide minimal in-memory stubs sufficient for exercising the FastAPI app.
+    """
+
+    # Create parent packages
+    services_pkg = types.ModuleType("services")
+    sys.modules.setdefault("services", services_pkg)
+
+    # services.resolver_service
+    resolver_service_mod = types.ModuleType("services.resolver_service")
+
+    class ResolutionResultStub:
+        def __init__(
+            self,
+            type: str,
+            uri: Optional[str] = None,
+            permanent: bool = False,
+            cache_ttl: Optional[int] = None,
+            quality: Optional[float] = None,
+            data: Optional[Dict[str, Any]] = None,
+            etag: Optional[str] = None,
+        ) -> None:
+            self.type = type
+            self.uri = uri
+            self.permanent = permanent
+            self.cache_ttl = cache_ttl
+            self.quality = quality
+            self.data = data
+            self.etag = etag
+
+    class ResolverService:
+        async def resolve(self, linkid, request_params):
+            # Default behavior: redirect to a synthetic location
+            return ResolutionResultStub(
+                type="redirect",
+                uri=f"https://example.org/resource/{linkid}",
+                permanent=False,
+                cache_ttl=300,
+                quality=1.0,
+            )
+
+        async def register(self, payload: Dict[str, Any]):
+            class _RegisterResult:
+                def __init__(self) -> None:
+                    self.id = "A" * 32
+                    self.created = 1700000000
+
+            return _RegisterResult()
+
+        async def update(self, linkid: str, updates: Dict[str, Any], user_sub: str):
+            return None
+
+        async def withdraw(self, linkid: str, data: Optional[Dict[str, Any]], user_sub: str):
+            return None
+
+    resolver_service_mod.ResolverService = ResolverService
+    sys.modules["services.resolver_service"] = resolver_service_mod
+
+    # services.cache_service
+    cache_service_mod = types.ModuleType("services.cache_service")
+
+    class CacheService:
+        async def connect(self):
+            return True
+
+        async def cleanup(self):
+            return True
+
+        async def health_check(self):
+            return True
+
+    cache_service_mod.CacheService = CacheService
+    sys.modules["services.cache_service"] = cache_service_mod
+
+    # services.registry_service
+    registry_service_mod = types.ModuleType("services.registry_service")
+
+    class RegistryService:
+        async def connect(self):
+            return True
+
+        async def cleanup(self):
+            return True
+
+        async def health_check(self):
+            return True
+
+    registry_service_mod.RegistryService = RegistryService
+    sys.modules["services.registry_service"] = registry_service_mod
+
+    # services.auth_service
+    auth_service_mod = types.ModuleType("services.auth_service")
+
+    class _User:
+        def __init__(self, sub: str, scopes: Optional[list[str]] = None) -> None:
+            self.sub = sub
+            self.scopes = scopes or []
+
+    class AuthService:
+        async def authenticate(self, token: str):
+            if token == "unauthorized" or token is None:
+                return None
+            # Default: authenticated user with read+write scopes
+            return _User(sub="user-1", scopes=["read", "write"])
+
+        def has_scope(self, user: _User, scope: str) -> bool:
+            return scope in getattr(user, "scopes", [])
+
+    auth_service_mod.AuthService = AuthService
+    sys.modules["services.auth_service"] = auth_service_mod
+
+    # models
+    models_mod = types.ModuleType("models")
+    try:
+        from pydantic import BaseModel
+    except Exception:  # pragma: no cover - pydantic is in requirements
+        class BaseModel:  # type: ignore
+            pass
+
+    class LinkIDRecord(BaseModel):
+        id: str  # minimal placeholder
+
+    class ResolutionRequest(BaseModel):
+        format: Optional[str] = None
+        language: Optional[str] = None
+        version: Optional[int] = None
+        timestamp: Optional[str] = None
+        accept_header: Optional[str] = None
+        accept_language: Optional[str] = None
+        prefer_redirect: bool = True
+        # Compatibility for code paths calling .dict() (Pydantic v1 style)
+        def dict(self, *args, **kwargs):  # type: ignore[override]
+            try:
+                return self.model_dump(*args, **kwargs)  # Pydantic v2
+            except Exception:  # pragma: no cover
+                return super().dict(*args, **kwargs)  # Pydantic v1
+
+    class RegistrationRequest(BaseModel):
+        target_uri: str
+        media_type: Optional[str] = None
+        language: Optional[str] = None
+        metadata: Optional[Dict[str, Any]] = None
+
+    models_mod.LinkIDRecord = LinkIDRecord
+    models_mod.ResolutionRequest = ResolutionRequest
+    models_mod.RegistrationRequest = RegistrationRequest
+    sys.modules["models"] = models_mod
+
+    # config
+    config_mod = types.ModuleType("config")
+
+    class _Settings:
+        environment: str = "development"
+        allowed_origins = ["*"]
+        rate_limit_per_minute: int = 600
+        rate_limit_per_hour: int = 3600
+        host: str = "127.0.0.1"
+        port: int = 8080
+        log_level: str = "INFO"
+
+    config_mod.settings = _Settings()
+    sys.modules["config"] = config_mod
+
+
+@pytest.fixture(scope="session")
+def app_module():
+    """Import the FastAPI app module (`main`) with stubbed dependencies installed."""
+    _install_stub_modules()
+    import importlib
+
+    # Ensure resolver/python is on sys.path so `import main` works
+    from pathlib import Path
+    resolver_dir = Path(__file__).resolve().parents[1]
+    if str(resolver_dir) not in sys.path:
+        sys.path.insert(0, str(resolver_dir))
+
+    main = importlib.import_module("main")
+    return main
+
+
+@pytest.fixture()
+def client(app_module):
+    """Yield a TestClient with lifespan events executed."""
+    from fastapi.testclient import TestClient
+
+    with TestClient(app_module.app) as c:
+        yield c
+
+

--- a/resolver/python/tests/test_misc_endpoints.py
+++ b/resolver/python/tests/test_misc_endpoints.py
@@ -1,0 +1,28 @@
+def test_health_endpoint(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("status") == "healthy"
+    assert "services" in body
+    assert body["services"].get("registry") is True
+    assert body["services"].get("cache") is True
+
+
+def test_well_known_endpoint(client):
+    r = client.get("/.well-known/linkid-resolver")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["resolver"]["version"] == "1.0"
+    eps = body["resolver"]["endpoints"]
+    assert "resolve" in eps and "register" in eps
+
+
+def test_metrics_endpoint(client):
+    # hit a request to ensure counters increment
+    client.get("/health")
+    r = client.get("/metrics")
+    assert r.status_code == 200
+    text = r.text
+    assert "linkid_requests_total" in text
+    assert "linkid_request_duration_seconds" in text
+

--- a/resolver/python/tests/test_mutation_endpoints.py
+++ b/resolver/python/tests/test_mutation_endpoints.py
@@ -1,0 +1,75 @@
+from typing import Dict, Any
+
+
+def _auth_headers(token: str = "valid-token") -> Dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_register_success(client):
+    payload = {
+        "target_uri": "https://example.org/resource",
+        "media_type": "text/html",
+        "language": "en",
+        "metadata": {"k": "v"},
+    }
+    r = client.post("/register", json=payload, headers=_auth_headers())
+    assert r.status_code == 201
+    data = r.json()
+    assert "id" in data and len(data["id"]) >= 32
+    assert data["uri"].startswith("https://w3id.org/linkid/")
+
+
+def test_register_requires_auth(client):
+    r = client.post("/register", json={"target_uri": "https://x"})
+    assert r.status_code == 401
+
+
+def test_register_requires_write_scope(client, monkeypatch):
+    # Patch AuthService.has_scope to deny write
+    from services.auth_service import AuthService
+
+    def deny_write(self, user, scope: str) -> bool:
+        if scope == "write":
+            return False
+        return True
+
+    monkeypatch.setattr(AuthService, "has_scope", deny_write)
+
+    r = client.post("/register", json={"target_uri": "https://x"}, headers=_auth_headers())
+    assert r.status_code == 403
+
+
+def test_update_success(client):
+    linkid = "E" * 32
+    updates: Dict[str, Any] = {"target_uri": "https://example.org/new"}
+    r = client.put(f"/resolve/{linkid}", json=updates, headers=_auth_headers())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["id"] == linkid
+    assert "updated" in body
+
+
+def test_withdraw_success(client):
+    linkid = "F" * 32
+    r = client.delete(
+        f"/resolve/{linkid}",
+        json={"reason": "owner request"},
+        headers=_auth_headers(),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["id"] == linkid
+    assert body.get("reason") == "owner request"
+
+
+def test_update_requires_auth(client):
+    linkid = "G" * 32
+    r = client.put(f"/resolve/{linkid}", json={"target_uri": "https://x"})
+    assert r.status_code == 401
+
+
+def test_withdraw_requires_auth(client):
+    linkid = "H" * 32
+    r = client.delete(f"/resolve/{linkid}")
+    assert r.status_code == 401
+

--- a/resolver/python/tests/test_resolution_endpoint.py
+++ b/resolver/python/tests/test_resolution_endpoint.py
@@ -1,0 +1,73 @@
+import types
+
+
+def test_resolve_redirect_default(client, app_module, monkeypatch):
+    linkid = "A" * 32
+    r = client.get(f"/resolve/{linkid}")
+    assert r.status_code in (301, 302)
+    assert r.headers.get("Location") == f"https://example.org/resource/{linkid}"
+    assert "X-LinkID-Resolver" in r.headers
+    assert "X-LinkID-Quality" in r.headers
+
+
+def test_resolve_metadata_variant(client, app_module, monkeypatch):
+    # Override resolver_service.resolve to return metadata
+    class MetaResult:
+        def __init__(self):
+            self.type = "metadata"
+            self.data = {"id": "A" * 32, "target": "https://example.org/x"}
+            self.cache_ttl = 120
+            self.etag = "W/\"abc\""
+
+    async def fake_resolve(self, linkid, params):
+        return MetaResult()
+
+    # monkeypatch the ResolverService.resolve method
+    from services.resolver_service import ResolverService
+    monkeypatch.setattr(ResolverService, "resolve", fake_resolve)
+
+    linkid = "B" * 32
+    r = client.get(f"/resolve/{linkid}?metadata=true")
+    assert r.status_code == 200
+    assert r.headers.get("Content-Type") == "application/linkid+json"
+    body = r.json()
+    assert body["id"] == "B" * 32
+    assert body["target"] == "https://example.org/x"
+
+
+def test_resolve_not_found(client, app_module, monkeypatch):
+    class NotFoundError(Exception):
+        def __init__(self):
+            self.code = "LINKID_NOT_FOUND"
+
+    async def fake_resolve(self, linkid, params):
+        raise NotFoundError()
+
+    from services.resolver_service import ResolverService
+    monkeypatch.setattr(ResolverService, "resolve", fake_resolve)
+
+    linkid = "C" * 32
+    r = client.get(f"/resolve/{linkid}")
+    assert r.status_code == 404
+    assert r.json()["detail"]["error"] == "LinkID not found"
+
+
+def test_resolve_withdrawn(client, app_module, monkeypatch):
+    class WithdrawnError(Exception):
+        def __init__(self):
+            self.code = "LINKID_WITHDRAWN"
+            self.tombstone = {"reason": "Withdrawn by owner"}
+
+    async def fake_resolve(self, linkid, params):
+        raise WithdrawnError()
+
+    from services.resolver_service import ResolverService
+    monkeypatch.setattr(ResolverService, "resolve", fake_resolve)
+
+    linkid = "D" * 32
+    r = client.get(f"/resolve/{linkid}")
+    assert r.status_code == 410
+    body = r.json()
+    assert body["detail"]["error"] == "LinkID withdrawn"
+    assert body["detail"]["tombstone"]["reason"] == "Withdrawn by owner"
+

--- a/spec/index.html
+++ b/spec/index.html
@@ -37,6 +37,13 @@
   </section>
 
   <section>
+    <h2>Companion Documents</h2>
+    <ul>
+      <li><a href="patent-alignment.html">Patent Alignment & Use Cases (Non‑Normative)</a></li>
+    </ul>
+  </section>
+
+  <section>
     <h2>Goals and Non‑Goals</h2>
     <ul>
       <li>Provide stable identifiers that resolve to the current best resource ("never‑break" links).</li>

--- a/spec/patent-alignment.html
+++ b/spec/patent-alignment.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>LinkID — Patent Alignment & Use Cases (Non‑Normative)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+  <script class="remove">
+    const respecConfig = {
+      specStatus: "CG-DRAFT",
+      shortName: "linkid-patent-alignment",
+      editors: [
+        { name: "Link Genetic GmbH", url: "https://linkgenetic.com/" }
+      ],
+      github: "https://github.com/linkgenetic/linkid-spec",
+      edDraftURI: "https://linkgenetic.github.io/linkid-spec/patent-alignment",
+      license: "w3c-software-doc",
+      xref: true,
+      group: "wicg",
+      lint: {"no-unused-dfns": false}
+    };
+  </script>
+  <style>
+    pre.algorithm { background: #f7f7f7; padding: 1rem; border-radius: 8px; overflow:auto }
+    code { white-space: pre-wrap; }
+    .issue { border-left: 4px solid #d00; padding-left: .6rem; }
+    .note { border-left: 4px solid #0a7; padding-left: .6rem; }
+  </style>
+</head>
+<body>
+  <section id="abstract">
+    <p>This non‑normative companion summarizes how the LinkID specification aligns with patent <strong>P220889 – System and Method for Resilient Identification and Management of Hyperlinks</strong> and consolidates illustrative use cases derived from the patent text. It is intended to help implementers and reviewers understand scope and intent; it does not add normative requirements.</p>
+  </section>
+
+  <section>
+    <h2>Status of This Document</h2>
+    <p>This page is informative. For normative behavior, see the main specification: <a href="index.html">LinkID — Persistent, Never‑Break Identifiers for the Web</a>.</p>
+  </section>
+
+  <section>
+    <h2>Patent‑to‑Spec Alignment</h2>
+    <p>The patent describes a system comprising a LinkID generator, a source registry, a destination registry, a LinkID mapping module, and a resolver that may employ semantic methods. These concepts correspond to sections in the LinkID specification as follows.</p>
+    <table>
+      <thead><tr><th>Patent component</th><th>Spec mapping</th></tr></thead>
+      <tbody>
+        <tr>
+          <td>LinkID generator (UUID/hash/AI signature)</td>
+          <td><a href="index.html#identifier-syntax">Identifier Syntax</a> (id format); <a href="index.html#data-model">Data Model</a> (<code>id</code> field)</td>
+        </tr>
+        <tr>
+          <td>Source/Destination registries; bidirectional queries</td>
+          <td><a href="index.html#data-model">Data Model</a> (<code>records</code>, metadata); <a href="index.html#http-api">HTTP API</a> (<code>/records/{id}</code>, mutations)</td>
+        </tr>
+        <tr>
+          <td>LinkID mapping module</td>
+          <td><a href="index.html#linkid-resolution">LinkID Resolution</a> (candidate selection, policy); <a href="index.html#caching">Caching</a></td>
+        </tr>
+        <tr>
+          <td>Resolver module with semantic fallback</td>
+          <td><a href="index.html#linkid-resolution">Resolution Algorithm</a> (normative flow, fallbacks); <a href="index.html#error-handling">Error Handling</a></td>
+        </tr>
+        <tr>
+          <td>Security, auditability, governance</td>
+          <td><a href="index.html#security-considerations">Security Considerations</a>; <a href="index.html#registry-and-governance">Registry and Governance</a></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="note">The main specification deliberately expresses behavior in Web‑native terms (HTTP, media types, well‑known discovery). Semantic or AI‑assisted replacement is treated as an implementation detail within policy and fallback, without imposing specific models.</div>
+  </section>
+
+  <section>
+    <h2>Identifier Forms</h2>
+    <ul>
+      <li><strong>HTTP form (recommended):</strong> <code>https://w3id.org/linkid/{id}</code> or an issuer‑scoped base. See <a href="index.html#identifier-syntax">Identifier Syntax</a>.</li>
+      <li><strong>Optional <code>lid:</code> scheme:</strong> If standardized via IETF, <code>lid:{id}</code> resolves via HTTPS bootstrap. The main spec documents this as optional and non‑blocking.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Illustrative Use Cases</h2>
+    <ol>
+      <li><strong>Enterprise documents (PDF/Word):</strong> Embed LinkIDs instead of direct URLs. Resolutions remain stable across migrations; archived or alternate targets can be selected by policy.</li>
+      <li><strong>Web site restructuring:</strong> CMS replaces paths; existing LinkIDs continue to redirect to current canonical locations.</li>
+      <li><strong>Long‑term archiving:</strong> Archives maintain historical records; <code>?at=</code> enables time‑based resolution for audits/reproducibility.</li>
+      <li><strong>API integration:</strong> Third‑party systems register/update records via HTTPS APIs; idempotent mutations, webhooks for lifecycle events.</li>
+      <li><strong>ECM systems (e.g., SharePoint/AEM):</strong> Automatic minting on save; resolver validates availability and selects alternates on failure.</li>
+      <li><strong>Offline media (QR, print):</strong> LinkIDs in print resolve to current best resources when scanned.</li>
+    </ol>
+    <p>See also <a href="index.html#examples">Examples</a> and <a href="index.html#http-api">HTTP API</a> for concrete exchanges.</p>
+  </section>
+
+  <section>
+    <h2>Sustainability</h2>
+    <p>By reducing link rot, minimizing duplication, and enabling effective caching, LinkID supports digital sustainability goals. See <a href="index.html#sustainability-and-environmental-impact">Sustainability and Environmental Impact</a> for recommended telemetry and measurements.</p>
+  </section>
+
+  <section>
+    <h2>Security & Governance Notes</h2>
+    <ul>
+      <li>Sign resolution documents and verify checksums when available (<a href="index.html#security-considerations">Security Considerations</a>).</li>
+      <li>Operate within a federated registry model with issuer verification (<a href="index.html#registry-and-governance">Registry and Governance</a>).</li>
+      <li>Use <code>/.well-known/linkid</code> to advertise resolver capabilities and keys (<a href="index.html#http-api">HTTP API</a>).</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Change Log</h2>
+    <ul>
+      <li>2025‑10‑09: Initial companion covering patent alignment and use cases.</li>
+    </ul>
+  </section>
+</body>
+</html>
+
+


### PR DESCRIPTION
- Add pytest-based test suite for FastAPI resolver covering health, discovery, metrics, resolution, and mutation endpoints.
- Uses lightweight stubs for missing runtime deps (`services`, `models`, `config`) with a `TestClient`.
- All tests live under `resolver/python/tests/` (`conftest.py`, misc, resolution, mutation).
- No production code touched; stubs only cover behaviors required by tests.
- Provides CI-ready foundation for API contract validation and future regression coverage.
