### PR TITLE
test suite for Java SDK impl

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -203,7 +203,7 @@ This document summarizes the complete implementation of Link Genetics' LinkID so
 4. **Standards adoption** through W3C and IETF processes
 
 ### Long-term (1-3 years)
-1. **Browser integration** for native lid: URI support
+1. **Browser integration** for native linkid: URI support
 2. **Global federation** of resolver networks
 3. **AI enhancement** for semantic resolution
 4. **Sustainability certification** and carbon offset programs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: run docker down test seed
+
+PY_DIR=resolver/python
+
+run:
+	cd $(PY_DIR) && LINKID_ENV=development LINKID_SEED_FILE=seed.json uvicorn main:app --host 0.0.0.0 --port 8080
+
+docker:
+	docker compose up --build
+
+down:
+	docker compose down
+
+test:
+	cd $(PY_DIR) && python3 -m pytest -q
+
+seed:
+	@echo "Seed is loaded at startup when LINKID_SEED_FILE is set"
+
+

--- a/README.md
+++ b/README.md
@@ -120,3 +120,38 @@ Tests live under [`/tests`](tests/).
 We aim to provide **two independent implementations** and **Web Platform Tests (WPT)** for conformance.
 
 ---
+
+## 🚦 Demo Quickstart (Python Resolver)
+
+Run locally with Docker:
+
+```bash
+docker compose up --build
+# http://localhost:8080/health
+```
+
+Or run directly (requires Python 3.11+):
+
+```bash
+make run
+# loads resolver/python/seed.json at startup
+```
+
+Demo runbook (scripted):
+
+```bash
+bash demo/demo.sh
+```
+
+Postman: import `demo/LinkID.postman_collection.json` and set variables:
+- baseUrl: http://localhost:8080
+- token: demo
+
+Endpoints:
+- `GET /.well-known/linkid-resolver` — discovery
+- `GET /resolve/{id}` — redirect
+- `GET /resolve/{id}?metadata=true` — metadata JSON
+- `POST /register` — requires `Authorization: Bearer demo`
+- `PUT /resolve/{id}` — requires auth
+- `DELETE /resolve/{id}` — requires auth
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LinkID (`lid:`) — Persistent, Never-Break Identifiers for the Web
+# LinkID (`linkid:`) — Persistent, Never-Break Identifiers for the Web
 
 [![Spec Status](https://img.shields.io/badge/status-Community%20Draft-blue)](https://linkgenetic.github.io/lid/spec/)
 [![CI](https://github.com/Link-Genetic-GmbH/lid/actions/workflows/build.yml/badge.svg)](https://github.com/Link-Genetic-GmbH/lid/actions)
@@ -7,12 +7,12 @@
 
 ## 🌍 Overview
 
-**LinkID** (`lid:`) is a proposal for a **W3C/IETF standard** to provide *never-break* identifiers on the Web.  
+**LinkID** (`linkid:`) is a proposal for a **W3C/IETF standard** to provide *never-break* identifiers on the Web.  
 It complements existing systems (DOI, ARK, Handle) but is designed for general use across documents, websites, and archives.
 
 - Stable IDs even if resources move or change
 - Resolver algorithm with semantic/AI support
-- HTTP-based form (`https://w3id.org/linkid/...`) and optional `lid:` scheme
+- HTTP-based form (`https://w3id.org/linkid/...`) and optional `linkid:` scheme
 - Open ecosystem: reference resolvers, client SDKs, tests
 
 ---
@@ -30,13 +30,13 @@ and how it complements existing persistent identifier systems like DOI, ARK, or 
 
 ## 📄 IETF Draft
 
-The current Internet-Draft for the proposed `lid:` URI scheme is
-maintained in [`/draft/draft-linkgenetic-lid-uri-00.md`](draft/draft-linkgenetic-lid-uri-00.md).
+The current Internet-Draft for the proposed `linkid:` URI scheme is
+maintained in [`/draft/draft-linkgenetic-linkid-uri-00.md`](draft/draft-linkgenetic-linkid-uri-00.md).
 
 You can also convert it using [IETF Author Tools](https://author-tools.ietf.org/).
 
 This folder contains Internet-Draft source files for the proposed
-`lid:` URI scheme.
+`linkid:` URI scheme.
 
 ## Why does the header look strange?
 
@@ -52,6 +52,12 @@ IETF [kramdown-rfc](https://github.com/cabo/kramdown-rfc) toolchain.
 The Editor’s Draft is maintained in [`/spec/index.html`](spec/index.html).
 
 ➡️ For a human-friendly introduction, please see the [Explainer](docs/explainer.md).
+
+---
+
+## 📝 Change Log
+
+- 2025-10-16: Renamed proposed URI scheme from `lid:` to `linkid:` to avoid IANA collision.
 
 
 ---

--- a/demo/LinkID.postman_collection.json
+++ b/demo/LinkID.postman_collection.json
@@ -1,0 +1,67 @@
+{
+  "info": {
+    "name": "LinkID Demo",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Health",
+      "request": {"method": "GET", "url": "{{baseUrl}}/health"}
+    },
+    {
+      "name": "Well-known",
+      "request": {"method": "GET", "url": "{{baseUrl}}/.well-known/linkid-resolver"}
+    },
+    {
+      "name": "Resolve Redirect",
+      "request": {"method": "GET", "url": "{{baseUrl}}/resolve/{{linkId}}"}
+    },
+    {
+      "name": "Resolve Metadata",
+      "request": {"method": "GET", "url": "{{baseUrl}}/resolve/{{linkId}}?metadata=true"}
+    },
+    {
+      "name": "Register",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Authorization", "value": "Bearer {{token}}"}],
+        "url": "{{baseUrl}}/register",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"targetUri\": \"https://example.org/resource\",\n  \"mediaType\": \"text/html\",\n  \"language\": \"en\"\n}"
+        }
+      }
+    },
+    {
+      "name": "Update",
+      "request": {
+        "method": "PUT",
+        "header": [{"key": "Authorization", "value": "Bearer {{token}}"}],
+        "url": "{{baseUrl}}/resolve/{{linkId}}",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"targetUri\": \"https://example.org/new\"\n}"
+        }
+      }
+    },
+    {
+      "name": "Withdraw",
+      "request": {
+        "method": "DELETE",
+        "header": [{"key": "Authorization", "value": "Bearer {{token}}"}],
+        "url": "{{baseUrl}}/resolve/{{linkId}}",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"reason\": \"owner request\"\n}"
+        }
+      }
+    }
+  ],
+  "variable": [
+    {"key": "baseUrl", "value": "http://localhost:8080"},
+    {"key": "token", "value": "demo"},
+    {"key": "linkId", "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}
+  ]
+}
+
+

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,40 @@
+# Demo & Recorded Fallback
+
+This folder contains assets to run the live demo and a recorded fallback.
+
+## Live Demo
+
+- Start the resolver:
+  - Docker: `docker compose up --build`
+  - Local: `make run`
+- Scripted flow: `bash demo.sh`
+- Postman: import `LinkID.postman_collection.json`
+
+## Recorded Fallback (terminal)
+
+Use `asciinema` to record a session:
+
+```bash
+# macOS: brew install asciinema
+asciinema rec demo.cast
+# run: bash demo.sh
+# press Ctrl-D to finish
+```
+
+Replay later:
+
+```bash
+asciinema play demo.cast
+```
+
+## Snapshots
+
+If running live is not possible, use the static snapshots under `snapshots/` to show
+expected responses for key endpoints.
+
+- `health.json` — expected `/health` payload
+- `wellknown.json` — expected `/.well-known/linkid-resolver` payload
+
+> Note: IDs and timestamps are illustrative.
+
+

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-http://localhost:8080}
+TOKEN=${TOKEN:-demo}
+
+echo "# Health" && curl -s ${BASE_URL}/health | jq . || true
+echo
+echo "# Well-known" && curl -s ${BASE_URL}/.well-known/linkid-resolver | jq . || true
+echo
+
+echo "# Register" 
+REG=$(curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -d '{"targetUri":"https://example.org/resource","mediaType":"text/html","language":"en"}' \
+  ${BASE_URL}/register)
+echo "$REG" | jq . || echo "$REG"
+LINK_ID=$(echo "$REG" | jq -r .id 2>/dev/null || echo "")
+
+if [[ -z "$LINK_ID" || "$LINK_ID" == "null" ]]; then
+  echo "Failed to obtain link ID from registration" >&2
+  exit 1
+fi
+
+echo
+echo "# Resolve redirect" && curl -s -I ${BASE_URL}/resolve/${LINK_ID} | sed -n '1,10p'
+echo
+echo "# Resolve metadata" && curl -s ${BASE_URL}/resolve/${LINK_ID}?metadata=true | jq . || true
+echo
+echo "# Update" && curl -s -X PUT -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+  -d '{"targetUri":"https://example.org/new"}' ${BASE_URL}/resolve/${LINK_ID} | jq . || true
+echo
+echo "# Withdraw" && curl -s -X DELETE -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+  -d '{"reason":"owner request"}' ${BASE_URL}/resolve/${LINK_ID} | jq . || true
+
+

--- a/demo/snapshots/health.json
+++ b/demo/snapshots/health.json
@@ -1,0 +1,11 @@
+{
+  "status": "healthy",
+  "timestamp": 1700000000,
+  "version": "1.0.0",
+  "services": {
+    "registry": true,
+    "cache": true
+  }
+}
+
+

--- a/demo/snapshots/wellknown.json
+++ b/demo/snapshots/wellknown.json
@@ -1,0 +1,30 @@
+{
+  "resolver": {
+    "version": "1.0",
+    "endpoints": {
+      "resolve": "http://localhost:8080/resolve/{id}",
+      "register": "http://localhost:8080/register",
+      "update": "http://localhost:8080/resolve/{id}",
+      "withdraw": "http://localhost:8080/resolve/{id}"
+    },
+    "capabilities": [
+      "content-negotiation",
+      "caching",
+      "authentication",
+      "rate-limiting",
+      "federation",
+      "semantic-resolution"
+    ],
+    "supportedFormats": [
+      "application/linkid+json",
+      "application/json",
+      "text/html"
+    ],
+    "rateLimits": {
+      "perMinute": 600,
+      "perHour": 3600
+    }
+  }
+}
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.8"
+
+services:
+  linkid-resolver:
+    build: ./resolver/python
+    image: linkid/resolver-python:demo
+    container_name: linkid-resolver
+    ports:
+      - "8080:8080"
+    environment:
+      - LINKID_ENV=${LINKID_ENV}
+      - LINKID_HOST=0.0.0.0
+      - LINKID_PORT=${LINKID_PORT}
+      - LINKID_LOG_LEVEL=${LINKID_LOG_LEVEL}
+      - LINKID_SEED_FILE=${LINKID_SEED_FILE}
+    restart: unless-stopped
+
+

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -17,7 +17,7 @@ Existing persistent identifier systems (e.g., DOI, Handle, ARK) address some of 
 ## Goals
 
 * Provide a **universal, Web-native identifier** that guarantees resolution even if the original resource moves or changes.
-* Offer a **simple syntax** (e.g., `lid:` scheme or HTTP-based `https://w3id.org/linkid/...`).
+* Offer a **simple syntax** (e.g., `linkid:` scheme or HTTP-based `https://w3id.org/linkid/...`).
 * Enable **resolvers** that map stable identifiers to current destinations using open, semantic, and AI-supported methods.
 * Ensure compatibility with existing Web infrastructure (HTTP, DNS, browsers, archives).
 * Support **sustainability claims** by quantifying avoided re-searching and duplication.
@@ -36,7 +36,7 @@ Existing persistent identifier systems (e.g., DOI, Handle, ARK) address some of 
 
 * **Identifier Syntax**:
 
-  * Option A: new URI scheme `lid:<UUID or hash>`
+  * Option A: new URI scheme `linkid:<UUID or hash>`
   * Option B: HTTP namespace `https://w3id.org/linkid/<UUID>`
 * **Resolver Module**:
 
@@ -70,7 +70,7 @@ Existing persistent identifier systems (e.g., DOI, Handle, ARK) address some of 
 
 ## Stakeholders & Adoption
 
-* **Browsers**: optional native resolution for `lid:` scheme.
+* **Browsers**: optional native resolution for `linkid:` scheme.
 * **Content creators**: embed `LinkIDs` in documents, PDFs, websites.
 * **Libraries & archives**: align with DOI, ARK, Handle communities.
 * **Industry & governments**: ensure long-term referenceability of policies, contracts, knowledge bases.

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -84,3 +84,30 @@ Existing persistent identifier systems (e.g., DOI, Handle, ARK) address some of 
 * [RFC 3986 – Uniform Resource Identifier (URI): Generic Syntax](https://www.rfc-editor.org/rfc/rfc3986)
 * [RFC 7595 – Guidelines and Registration Procedures for URI Schemes](https://www.rfc-editor.org/rfc/rfc7595)
 * [w3id.org Permanent Identifier Community Group](https://w3id.org/)
+
+---
+
+## Conference Session Overview
+
+Broken links threaten the long-term integrity and trustworthiness of the Web.
+
+The Link Genetic initiative introduces “LinkID”, a persistent, bidirectional identifier scheme designed to ensure link resilience, metadata preservation, and semantic interoperability across domains and over time.
+
+This session invites W3C members to discuss the feasibility of a new `linkid:` URI scheme, alignment with existing identifier systems (DOI, ARK, UUID), and next steps toward standardisation.
+
+We plan to:
+
+- Identify potential Working Groups or Community Groups interested in hosting a LinkID proposal.
+- Discuss governance, persistence, and interoperability models for resilient linking.
+- Outline a roadmap for open-source reference implementation and metadata framework.
+
+Goal(s): Gather feedback from W3C TAG, URI, and Web Architecture communities on the LinkID concept.
+
+Agenda:
+
+1. Introduction to Link Genetic & LinkID (5 min)
+2. Challenges of link persistence and metadata loss (10 min)
+3. Overview of the LinkID proposal and URI scheme draft (15 min)
+4. Discussion: interoperability with DOI/ARK/UUID (20 min)
+5. Next steps and standardisation pathways (10 min)
+

--- a/docs/slides.md
+++ b/docs/slides.md
@@ -1,0 +1,67 @@
+---
+marp: true
+theme: default
+paginate: true
+---
+
+# LinkID: Resilient, Persistent Links for the Web
+
+Link Genetic — W3C discussion session
+
+---
+
+## The Problem: Broken Links
+
+- Links rot; content moves; formats change
+- Trust, accessibility, and preservation suffer
+- Costly re-searching and duplication
+
+---
+
+## LinkID at a Glance
+
+- Persistent identifier (`linkid:`) or `https://w3id.org/linkid/...`
+- Resolver maps LinkID → current target
+- Open, federated registries; semantic metadata
+- Complements DOI/ARK/UUID; interoperable by design
+
+---
+
+## Proposal Highlights
+
+- URI scheme draft (IETF) and HTTP namespace
+- Resolution API (redirect or metadata)
+- Governance and persistence models
+
+---
+
+## Interoperability
+
+- Alignment with DOI / ARK / UUID
+- Mapping strategies and compatibility
+
+---
+
+## Roadmap
+
+- Open-source reference implementation (this demo)
+- SDKs (JS/Java/Python)
+- Conformance tests and metadata framework
+
+---
+
+## Discussion & Next Steps
+
+- Candidate WGs or Community Groups
+- Feedback from TAG, URI, WebArch
+- Standardisation pathways
+
+---
+
+## Live Demo
+
+- GET `/.well-known/linkid-resolver`
+- Resolve → redirect / metadata
+- Register, update, withdraw
+
+

--- a/draft/draft-linkgenetic-lid-uri-00.md
+++ b/draft/draft-linkgenetic-lid-uri-00.md
@@ -1,7 +1,7 @@
 ---
-title: The LinkID (lid) URI Scheme
+title: The LinkID (linkid) URI Scheme
 abbrev: LinkID URI
-docname: draft-linkgenetic-lid-uri-00
+docname: draft-linkgenetic-linkid-uri-00
 category: std
 ipr: trust200902
 area: ART
@@ -18,7 +18,7 @@ author:
 
 # Abstract
 
-This document defines the `lid` URI scheme, a persistent identifier
+This document defines the `linkid` URI scheme, a persistent identifier
 for Web resources that resolves through HTTPS-based resolvers.
 It is intended as a general-purpose complement to existing identifier
 systems such as DOI, Handle, and ARK, enabling stable linking across
@@ -37,7 +37,7 @@ Handle, and ARK. However, their adoption is mostly limited to
 specific communities (e.g., academic publishing, libraries). The Web
 as a whole lacks a universal, Web-native persistent identifier scheme.
 
-The `lid` URI scheme aims to fill this gap by providing stable,
+The `linkid` URI scheme aims to fill this gap by providing stable,
 location-independent identifiers that always resolve to the current
 best representation of a resource.
 
@@ -53,7 +53,7 @@ This document uses the following terms:
 
 - **LinkID (lid)**: A persistent, location-independent identifier
   assigned to a resource.
-- **Client**: Software that dereferences a `lid:` URI.
+- **Client**: Software that dereferences a `linkid:` URI.
 - **Resolver**: An HTTPS service that maps a LinkID to one or more
   current resource representations or redirect targets.
 - **Registry**: An authority that issues LinkIDs and curates resolution
@@ -77,10 +77,10 @@ This document uses the following terms:
 
 # URI Scheme Definition
 
-The `lid` URI has the following syntax:
+The `linkid` URI has the following syntax:
 
 ```
-lid:<id>[?<parameters>]
+linkid:<id>[?<parameters>]
 ```
 
 Where:
@@ -93,15 +93,15 @@ Where:
 
 ## Syntax (ABNF)
 
-The `lid` URI syntax is formally defined using ABNF as per [RFC5234]
+The `linkid` URI syntax is formally defined using ABNF as per [RFC5234]
 and [RFC3986]:
 
 ```
-lid-URI     = "lid:" lid-id [ "?" lid-params ]
-lid-id      = 1*( lid-unreserved / pct-encoded )
-lid-unreserved = ALPHA / DIGIT / "." / "_" / "~" / "-"
+linkid-URI     = "linkid:" linkid-id [ "?" linkid-params ]
+linkid-id      = 1*( linkid-unreserved / pct-encoded )
+linkid-unreserved = ALPHA / DIGIT / "." / "_" / "~" / "-"
 
-lid-params  = param *( "&" param )
+linkid-params  = param *( "&" param )
 param       = pname [ "=" pvalue ]
 pname       = 1*( pchar )
 pvalue      = *pchar
@@ -123,7 +123,7 @@ Notes:
 
 ## Parsing, Normalization, and Comparison
 
-- The scheme `lid` is case-insensitive; it SHOULD be rendered in
+- The scheme `linkid` is case-insensitive; it SHOULD be rendered in
   lowercase.
 - The `<id>` component is treated as an opaque, case-sensitive string.
   Registries MAY impose additional constraints; clients MUST NOT.
@@ -131,7 +131,7 @@ Notes:
   remove unnecessary percent-encoding for unreserved characters.
 - Parameters used for content negotiation (e.g., `format`, `lang`,
   `profile`, `version`) do not change the identity of the LinkID; they
-  influence resolution outcomes. Equality of two `lid:` URIs is
+  influence resolution outcomes. Equality of two `linkid:` URIs is
   determined solely by the scheme and `<id>` after normalization.
 - Parameter ordering is not significant; duplicate parameter names MUST
   be processed by taking the first occurrence and ignoring subsequent
@@ -442,7 +442,7 @@ A conforming client:
 
 # Interoperability
 
-The `lid` scheme is designed to interoperate with existing Web
+The `linkid` scheme is designed to interoperate with existing Web
 infrastructure (HTTP, DNS, CDNs, archives). It can coexist with DOI,
 Handle, and ARK identifiers by cross-referencing or embedding them as
 alternate resolution records.
@@ -488,20 +488,20 @@ Additionally, resolvers SHOULD:
 
 # IANA Considerations
 
-IANA is requested to register the `lid` URI scheme in the
+IANA is requested to register the `linkid` URI scheme in the
 “Uniform Resource Identifier (URI) Schemes” registry in accordance
 with RFC 7595.
 
 ## URI Scheme Registration Template
 
-- **Scheme name:** `lid`  
+- **Scheme name:** `linkid`  
 - **Status:** Permanent  
 - **Applications/protocols that use this scheme name:** LinkID for
   persistent identifiers, resolved via HTTPS.  
 - **Contact:** Link Genetic GmbH <info@linkgenetic.com>  
 - **Change controller:** IETF  
 - **References:** This document, RFC3986, RFC7595  
-- **Syntax:** `lid:<id>[?<parameters>]`  
+- **Syntax:** `linkid:<id>[?<parameters>]`  
 - **Semantics:** Persistent, location-independent identifiers resolved
   via HTTPS.  
 - **Encoding considerations:** URL-safe characters, percent-encoding
@@ -511,8 +511,8 @@ with RFC 7595.
 - **Security considerations:** HTTPS, signatures, anti-phishing.  
 - **Privacy considerations:** No personal data, opaque IDs.  
 - **Examples:**  
-  - `lid:b2f6f0d7c7d34e3e8a4f0a6b2a9c9f14`  
-  - `lid:b2f6f0d7c7d34e3e8a4f0a6b2a9c9f14?format=pdf&lang=en`
+  - `linkid:b2f6f0d7c7d34e3e8a4f0a6b2a9c9f14`  
+  - `linkid:b2f6f0d7c7d34e3e8a4f0a6b2a9c9f14?format=pdf&lang=en`
 
 ## Well-Known URI Registration
 
@@ -539,7 +539,7 @@ IANA is requested to register the `application/linkid+json` media type:
 - **Applications that use this media type:** LinkID resolvers and
   clients  
 - **Fragment identifier considerations:** As per [RFC6901] if used  
-- **Additional information:** File extension: `.lid.json` (optional)  
+- **Additional information:** File extension: `.linkid.json` (optional)  
 - **Person & email address to contact for further information:** Link
   Genetic GmbH <info@linkgenetic.com>  
 - **Intended usage:** Common  

--- a/examples/resolve.py
+++ b/examples/resolve.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Minimal example using the LinkID Python client against the local resolver.
+
+Usage:
+  python examples/resolve.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Ensure SDK is importable
+ROOT = Path(__file__).resolve().parents[1]
+SDK_PY = ROOT / "sdk" / "python"
+sys.path.insert(0, str(SDK_PY))
+
+from client import LinkIDClient  # type: ignore
+
+
+def main() -> None:
+    base_url = os.environ.get("BASE_URL", "http://localhost:8080")
+    api_key = os.environ.get("API_KEY", "demo")
+
+    client = LinkIDClient(resolver_url=base_url, api_key=api_key)
+
+    print("Registering...")
+    reg = client.register({
+        "targetUri": "https://example.org/resource",
+        "mediaType": "text/html",
+        "language": "en",
+    })
+    link_id = reg["id"]
+    print("Registered:", reg)
+
+    print("Resolve (metadata)...")
+    meta = client.resolve(link_id, metadata=True)
+    print(meta)
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/resolver/python/Dockerfile
+++ b/resolver/python/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+ && pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+# Defaults for demo; can be overridden
+ENV LINKID_ENV=production \
+    LINKID_HOST=0.0.0.0 \
+    LINKID_PORT=8080 \
+    LINKID_LOG_LEVEL=INFO \
+    LINKID_SEED_FILE=seed.json
+
+EXPOSE 8080
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+
+

--- a/resolver/python/config.py
+++ b/resolver/python/config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    environment: str = "development"
+    allowed_origins: list[str] = ["*"]
+    rate_limit_per_minute: int = 600
+    rate_limit_per_hour: int = 3600
+    host: str = "127.0.0.1"
+    port: int = 8080
+    log_level: str = "INFO"
+    seed_file: str | None = None
+
+    class Config:
+        env_prefix = "LINKID_"
+        case_sensitive = False
+
+
+settings = Settings()
+
+

--- a/resolver/python/main.py
+++ b/resolver/python/main.py
@@ -27,6 +27,7 @@ from services.registry_service import RegistryService
 from services.auth_service import AuthService
 from models import LinkIDRecord, ResolutionRequest, RegistrationRequest
 from config import settings
+from seed import load_seed
 
 # Configure structured logging
 structlog.configure(
@@ -100,6 +101,14 @@ async def lifespan(app: FastAPI):
     # Connect to databases
     await registry_service.connect()
     await cache_service.connect()
+
+    # Optional: load seed data when configured
+    if settings.seed_file:
+        try:
+            created_ids = await load_seed(registry_service, settings.seed_file)
+            logger.info("Seed loaded", count=len(created_ids))
+        except Exception as e:
+            logger.error("Seed load failed", error=str(e))
 
     logger.info("LinkID Resolver started successfully")
 

--- a/resolver/python/models.py
+++ b/resolver/python/models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
+
+
+class LinkIDRecord(BaseModel):
+    id: str
+
+
+class ResolutionRequest(BaseModel):
+    format: Optional[str] = None
+    language: Optional[str] = None
+    version: Optional[int] = None
+    timestamp: Optional[str] = None
+    accept_header: Optional[str] = None
+    accept_language: Optional[str] = None
+    prefer_redirect: bool = True
+
+    # Compatibility shim for code paths calling .dict() (Pydantic v1 style)
+    def dict(self, *args, **kwargs):  # type: ignore[override]
+        try:
+            return self.model_dump(*args, **kwargs)  # Pydantic v2
+        except Exception:  # pragma: no cover
+            return super().dict(*args, **kwargs)
+
+
+class RegistrationRequest(BaseModel):
+    # Accept both target_uri and targetUri
+    target_uri: str = Field(alias="targetUri")
+    media_type: Optional[str] = Field(default=None, alias="mediaType")
+    language: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+    class Config:
+        populate_by_name = True
+
+

--- a/resolver/python/seed.json
+++ b/resolver/python/seed.json
@@ -1,0 +1,24 @@
+[
+  {
+    "target_uri": "https://example.org/resource/normal",
+    "media_type": "text/html",
+    "language": "en",
+    "metadata": {"title": "Normal record"}
+  },
+  {
+    "target_uri": "https://example.org/resource/withdrawn",
+    "media_type": "application/pdf",
+    "language": "en",
+    "metadata": {"title": "Withdrawn record"},
+    "withdrawn": true,
+    "withdrawal_reason": "Withdrawn by owner"
+  },
+  {
+    "targetUri": "https://example.org/resource/multilingual",
+    "mediaType": "text/html",
+    "language": "fr",
+    "metadata": {"title": "Multilingual/format variant", "variants": ["html", "pdf"]}
+  }
+]
+
+

--- a/resolver/python/seed.py
+++ b/resolver/python/seed.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from services.registry_service import RegistryService
+
+
+async def load_seed(registry: RegistryService, seed_path: str) -> List[str]:
+    """Load seed records from a JSON file into the registry.
+
+    Returns list of created link IDs.
+    """
+    path = Path(seed_path)
+    if not path.exists():
+        return []
+
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    created: List[str] = []
+    for entry in data:
+        payload: Dict[str, Any] = {
+            "target_uri": entry.get("target_uri") or entry.get("targetUri"),
+            "media_type": entry.get("media_type") or entry.get("mediaType"),
+            "language": entry.get("language"),
+            "metadata": entry.get("metadata") or {},
+        }
+        record = await registry.create(payload, issuer=entry.get("issuer") or "seed")
+        created.append(record.id)
+
+        if entry.get("withdrawn"):
+            await registry.withdraw(record.id, {"reason": entry.get("withdrawal_reason")}, user_sub=record.metadata.get("issuer", "seed"))
+
+    return created
+
+

--- a/resolver/python/services/__init__.py
+++ b/resolver/python/services/__init__.py
@@ -1,0 +1,17 @@
+"""Service package for the Python LinkID demo resolver.
+
+Provides minimal in-memory implementations for:
+- registry (records storage, versioning, tombstones)
+- cache (simple ephemeral cache hooks)
+- resolver (resolution logic using registry + cache)
+- auth (very simple bearer token handling)
+"""
+
+__all__ = [
+    "auth_service",
+    "cache_service",
+    "registry_service",
+    "resolver_service",
+]
+
+

--- a/resolver/python/services/auth_service.py
+++ b/resolver/python/services/auth_service.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class User:
+    sub: str
+    scopes: List[str]
+
+
+class AuthService:
+    """Very simple token-based auth for demo purposes.
+
+    - "demo" token → read+write
+    - "readonly" token → read only
+    - "unauthorized" or missing token → None
+    Any other token is treated as a valid user with read+write scopes.
+    """
+
+    async def authenticate(self, token: Optional[str]) -> Optional[User]:
+        if not token or token == "unauthorized":
+            return None
+        if token == "readonly":
+            return User(sub="demo-user", scopes=["read"]) 
+        # default: allow
+        return User(sub="demo-user", scopes=["read", "write"]) 
+
+    def has_scope(self, user: User, scope: str) -> bool:
+        return scope in getattr(user, "scopes", [])
+
+

--- a/resolver/python/services/cache_service.py
+++ b/resolver/python/services/cache_service.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional, Tuple
+
+
+class CacheService:
+    """Very small ephemeral cache for demo purposes."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Tuple[Any, float]] = {}
+
+    async def connect(self) -> bool:
+        return True
+
+    async def cleanup(self) -> bool:
+        self._store.clear()
+        return True
+
+    async def health_check(self) -> bool:
+        return True
+
+    def get(self, key: str) -> Optional[Any]:
+        entry = self._store.get(key)
+        if not entry:
+            return None
+        value, expires_at = entry
+        if expires_at < time.time():
+            self._store.pop(key, None)
+            return None
+        return value
+
+    def set(self, key: str, value: Any, ttl: int = 300) -> None:
+        self._store[key] = (value, time.time() + float(ttl))
+
+    def clear(self) -> None:
+        self._store.clear()
+
+

--- a/resolver/python/services/registry_service.py
+++ b/resolver/python/services/registry_service.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Dict, Optional, Tuple
+
+
+class Tombstone:
+    def __init__(self, reason: Optional[str] = None, at: Optional[float] = None) -> None:
+        self.reason = reason
+        self.at = at or time.time()
+
+
+class RegistryRecord:
+    def __init__(
+        self,
+        link_id: str,
+        target_uri: str,
+        media_type: Optional[str] = None,
+        language: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.id = link_id
+        self.target_uri = target_uri
+        self.media_type = media_type
+        self.language = language
+        self.metadata = metadata or {}
+        self.created = time.time()
+        self.updated = self.created
+        self.version = 1
+        self.withdrawn: Optional[Tombstone] = None
+
+
+class LinkIdNotFoundError(Exception):
+    def __init__(self, link_id: str) -> None:
+        self.code = "LINKID_NOT_FOUND"
+        self.link_id = link_id
+
+
+class LinkIdWithdrawnError(Exception):
+    def __init__(self, link_id: str, tombstone: Tombstone) -> None:
+        self.code = "LINKID_WITHDRAWN"
+        self.link_id = link_id
+        self.tombstone = {"reason": tombstone.reason, "at": tombstone.at}
+
+
+class UnauthorizedError(Exception):
+    def __init__(self) -> None:
+        self.code = "UNAUTHORIZED"
+
+
+class RegistryService:
+    """In-memory registry for demo purposes.
+
+    Stores LinkID records and supports basic versioning and withdrawal.
+    """
+
+    def __init__(self) -> None:
+        self._store: Dict[str, RegistryRecord] = {}
+
+    async def connect(self) -> bool:
+        return True
+
+    async def cleanup(self) -> bool:
+        return True
+
+    async def health_check(self) -> bool:
+        return True
+
+    def _generate_link_id(self) -> str:
+        # 32-char uppercase hex, matches allowed charset
+        return uuid.uuid4().hex.upper()
+
+    async def create(self, payload: Dict[str, Any], issuer: str) -> RegistryRecord:
+        link_id = self._generate_link_id()
+        record = RegistryRecord(
+            link_id=link_id,
+            target_uri=payload.get("target_uri") or payload.get("targetUri"),
+            media_type=payload.get("media_type") or payload.get("mediaType"),
+            language=payload.get("language"),
+            metadata=payload.get("metadata") or {},
+        )
+        record.metadata.setdefault("issuer", issuer)
+        self._store[link_id] = record
+        return record
+
+    async def get(self, link_id: str) -> RegistryRecord:
+        record = self._store.get(link_id)
+        if not record:
+            raise LinkIdNotFoundError(link_id)
+        if record.withdrawn is not None:
+            raise LinkIdWithdrawnError(link_id, record.withdrawn)
+        return record
+
+    async def get_any(self, link_id: str) -> RegistryRecord:
+        record = self._store.get(link_id)
+        if not record:
+            raise LinkIdNotFoundError(link_id)
+        return record
+
+    async def update(self, link_id: str, updates: Dict[str, Any], user_sub: str) -> None:
+        record = await self.get_any(link_id)
+        # Ownership check (best-effort for demo)
+        issuer = record.metadata.get("issuer")
+        if issuer and issuer != user_sub:
+            raise UnauthorizedError()
+
+        changed = False
+        if "target_uri" in updates or "targetUri" in updates:
+            record.target_uri = updates.get("target_uri") or updates.get("targetUri")
+            changed = True
+        if "media_type" in updates or "mediaType" in updates:
+            record.media_type = updates.get("media_type") or updates.get("mediaType")
+            changed = True
+        if "language" in updates:
+            record.language = updates["language"]
+            changed = True
+        if "metadata" in updates and isinstance(updates["metadata"], dict):
+            record.metadata.update(updates["metadata"]) 
+            changed = True
+
+        if changed:
+            record.version += 1
+            record.updated = time.time()
+
+    async def withdraw(self, link_id: str, data: Optional[Dict[str, Any]], user_sub: str) -> None:
+        record = await self.get_any(link_id)
+        issuer = record.metadata.get("issuer")
+        if issuer and issuer != user_sub:
+            raise UnauthorizedError()
+        record.withdrawn = Tombstone(reason=(data or {}).get("reason"))
+
+    async def resolve(self, link_id: str) -> Tuple[str, RegistryRecord]:
+        record = await self.get(link_id)
+        return record.target_uri, record
+
+

--- a/resolver/python/services/resolver_service.py
+++ b/resolver/python/services/resolver_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .registry_service import RegistryService, LinkIdNotFoundError, LinkIdWithdrawnError
+from .cache_service import CacheService
+
+
+@dataclass
+class ResolutionResult:
+    type: str  # "redirect" | "metadata"
+    uri: Optional[str] = None
+    permanent: bool = False
+    cache_ttl: Optional[int] = None
+    quality: Optional[float] = None
+    data: Optional[Dict[str, Any]] = None
+    etag: Optional[str] = None
+
+
+class ResolverService:
+    def __init__(self, registry: RegistryService, cache: CacheService, logger) -> None:
+        self.registry = registry
+        self.cache = cache
+        self.logger = logger
+
+    async def resolve(self, linkid: str, params) -> ResolutionResult:
+        try:
+            target_uri, record = await self.registry.resolve(linkid)
+        except LinkIdNotFoundError as e:
+            raise e
+        except LinkIdWithdrawnError as e:
+            raise e
+        except Exception as e:  # pragma: no cover - safety net
+            raise e
+
+        if getattr(params, "prefer_redirect", True):
+            return ResolutionResult(
+                type="redirect",
+                uri=target_uri,
+                permanent=False,
+                cache_ttl=300,
+                quality=1.0,
+            )
+
+        # metadata response
+        data = {
+            "id": record.id,
+            "target": record.target_uri,
+            "mediaType": record.media_type,
+            "language": record.language,
+            "created": record.created,
+            "updated": record.updated,
+            "version": record.version,
+            "metadata": record.metadata,
+        }
+        return ResolutionResult(
+            type="metadata",
+            data=data,
+            cache_ttl=120,
+            etag=f'W/"{record.version}-{int(record.updated)}"',
+        )
+
+    async def register(self, payload: Dict[str, Any]):
+        issuer = payload.get("issuer") or "unknown"
+        record = await self.registry.create(payload, issuer)
+
+        # For demo purposes, return a simple struct with required fields
+        class _Result:
+            def __init__(self, id: str, created: float) -> None:
+                self.id = id
+                self.created = created
+
+        return _Result(record.id, record.created)
+
+    async def update(self, linkid: str, updates: Dict[str, Any], user_sub: str) -> None:
+        await self.registry.update(linkid, updates or {}, user_sub)
+
+    async def withdraw(self, linkid: str, data: Optional[Dict[str, Any]], user_sub: str) -> None:
+        await self.registry.withdraw(linkid, data or {}, user_sub)
+
+

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -17,6 +17,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson.version>2.17.0</jackson.version>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <mockito.version>5.12.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -24,6 +26,24 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -35,6 +55,14 @@
                 <version>3.11.0</version>
                 <configuration>
                     <release>17</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
         </plugins>

--- a/sdk/java/src/test/java/org/linkgenetic/linkid/LinkIdClientTest.java
+++ b/sdk/java/src/test/java/org/linkgenetic/linkid/LinkIdClientTest.java
@@ -1,0 +1,340 @@
+package org.linkgenetic.linkid;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LinkIdClientTest {
+
+    private HttpServer server;
+    private URI baseUri;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.setExecutor(null);
+        server.start();
+        baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void resolve_redirects_are_returned_with_quality_and_headers() throws Exception {
+        String linkId = validLinkId();
+        String target = "https://example.com/abc";
+        server.createContext("/resolve/" + linkId, exchange -> {
+            assertEquals("GET", exchange.getRequestMethod());
+            exchange.getResponseHeaders().add("Location", target);
+            exchange.getResponseHeaders().add("X-LinkID-Quality", "0.87");
+            exchange.getResponseHeaders().add("X-LinkID-Resolver", "http://resolver.local");
+            sendResponse(exchange, 302, "");
+        });
+
+        LinkIdClient client = defaultClient();
+        LinkIdClient.ResolutionResult res = client.resolve(linkId);
+
+        assertTrue(res instanceof LinkIdClient.RedirectResolution);
+        LinkIdClient.RedirectResolution rr = (LinkIdClient.RedirectResolution) res;
+        assertEquals(linkId, rr.linkId());
+        assertEquals(target, rr.uri());
+        assertEquals("http://resolver.local", rr.resolver());
+        assertFalse(rr.cached());
+        assertEquals(OptionalDouble.of(0.87).getAsDouble(), rr.quality().orElseThrow());
+    }
+
+    @Test
+    void resolve_metadata_200_returns_payload_and_resolver_header() throws Exception {
+        String linkId = validLinkId();
+        ObjectNode body = mapper.createObjectNode().put("name", "ok");
+        server.createContext("/resolve/" + linkId, exchange -> {
+            assertEquals("GET", exchange.getRequestMethod());
+            exchange.getResponseHeaders().add("X-LinkID-Resolver", "http://resolver.meta");
+            exchange.getResponseHeaders().add("Cache-Control", "max-age=3600");
+            sendJson(exchange, 200, body);
+        });
+
+        LinkIdClient client = defaultClient();
+        LinkIdClient.ResolutionResult res = client.resolve(linkId, LinkIdClient.ResolveOptions.builder().metadata(true).build());
+
+        assertTrue(res instanceof LinkIdClient.MetadataResolution);
+        LinkIdClient.MetadataResolution mr = (LinkIdClient.MetadataResolution) res;
+        assertEquals("ok", mr.metadata().get("name").asText());
+        assertEquals("http://resolver.meta", mr.resolver());
+        assertFalse(mr.cached());
+    }
+
+    @Test
+    void resolve_uses_cache_and_sets_cached_flag() throws Exception {
+        String linkId = validLinkId();
+        AtomicInteger hits = new AtomicInteger();
+        ObjectNode body = mapper.createObjectNode().put("v", 1);
+        server.createContext("/resolve/" + linkId, exchange -> {
+            hits.incrementAndGet();
+            exchange.getResponseHeaders().add("Cache-Control", "max-age=3600");
+            sendJson(exchange, 200, body);
+        });
+
+        LinkIdClient client = defaultClient();
+        LinkIdClient.ResolutionResult res1 = client.resolve(linkId);
+        LinkIdClient.ResolutionResult res2 = client.resolve(linkId);
+
+        assertTrue(res2 instanceof LinkIdClient.MetadataResolution);
+        assertEquals(1, hits.get(), "second call should be served from cache");
+        assertFalse(((LinkIdClient.MetadataResolution) res1).cached());
+        assertTrue(((LinkIdClient.MetadataResolution) res2).cached());
+    }
+
+    @Test
+    void update_clears_cache_and_next_resolve_fetches_again() throws Exception {
+        String linkId = validLinkId();
+        AtomicInteger resolveHits = new AtomicInteger();
+        ObjectNode body1 = mapper.createObjectNode().put("v", 1);
+        ObjectNode body2 = mapper.createObjectNode().put("v", 2);
+
+        server.createContext("/resolve/" + linkId, exchange -> {
+            if (Objects.equals(exchange.getRequestMethod(), "PUT")) {
+                assertEquals("application/json", exchange.getRequestHeaders().getFirst("Content-Type"));
+                sendResponse(exchange, 204, "");
+                return;
+            }
+            resolveHits.incrementAndGet();
+            exchange.getResponseHeaders().add("Cache-Control", "max-age=3600");
+            if (resolveHits.get() == 1) {
+                sendJson(exchange, 200, body1);
+            } else {
+                sendJson(exchange, 200, body2);
+            }
+        });
+
+        LinkIdClient client = defaultClient();
+        LinkIdClient.ResolutionResult r1 = client.resolve(linkId);
+        assertEquals(1, resolveHits.get());
+
+        ObjectNode updateReq = new ObjectMapper().createObjectNode().put("note", "x");
+        client.update(linkId, updateReq);
+
+        LinkIdClient.ResolutionResult r2 = client.resolve(linkId);
+        assertEquals(2, resolveHits.get(), "Cache should be cleared by update");
+        assertEquals(2, ((LinkIdClient.MetadataResolution) r2).metadata().get("v").asInt());
+    }
+
+    @Test
+    void withdraw_clears_cache_and_next_resolve_fetches_again() throws Exception {
+        String linkId = validLinkId();
+        AtomicInteger resolveHits = new AtomicInteger();
+        ObjectNode body1 = mapper.createObjectNode().put("v", 1);
+        ObjectNode body2 = mapper.createObjectNode().put("v", 2);
+
+        server.createContext("/resolve/" + linkId, exchange -> {
+            if (Objects.equals(exchange.getRequestMethod(), "DELETE")) {
+                assertEquals("application/json", exchange.getRequestHeaders().getFirst("Content-Type"));
+                sendResponse(exchange, 204, "");
+                return;
+            }
+            resolveHits.incrementAndGet();
+            exchange.getResponseHeaders().add("Cache-Control", "max-age=3600");
+            if (resolveHits.get() == 1) {
+                sendJson(exchange, 200, body1);
+            } else {
+                sendJson(exchange, 200, body2);
+            }
+        });
+
+        LinkIdClient client = defaultClient();
+        client.resolve(linkId);
+        client.withdraw(linkId, mapper.createObjectNode().put("reason", "x"));
+        LinkIdClient.ResolutionResult r2 = client.resolve(linkId);
+        assertEquals(2, resolveHits.get());
+        assertEquals(2, ((LinkIdClient.MetadataResolution) r2).metadata().get("v").asInt());
+    }
+
+    @Test
+    void register_posts_body_and_returns_json() throws Exception {
+        AtomicInteger hits = new AtomicInteger();
+        server.createContext("/register", exchange -> {
+            hits.incrementAndGet();
+            assertEquals("POST", exchange.getRequestMethod());
+            assertEquals("application/json", exchange.getRequestHeaders().getFirst("Content-Type"));
+            String payload = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            JsonNode parsed = mapper.readTree(payload);
+            assertEquals("https://example.com/x", parsed.get("targetUri").asText());
+            sendJson(exchange, 201, mapper.createObjectNode().put("ok", true));
+        });
+
+        LinkIdClient client = clientWithApiKey("k123");
+        LinkIdClient.RegistrationRequest req = LinkIdClient.RegistrationRequest.builder()
+            .targetUri("https://example.com/x")
+            .mediaType("text/html")
+            .language("en")
+            .metadata(new ObjectMapper().createObjectNode().put("k", "v"))
+            .build();
+
+        JsonNode resp = client.register(req);
+        assertTrue(resp.get("ok").asBoolean());
+        assertEquals(1, hits.get());
+    }
+
+    @Test
+    void headers_include_accept_user_agent_and_authorization() throws Exception {
+        String linkId = validLinkId();
+        server.createContext("/resolve/" + linkId, exchange -> {
+            assertEquals("LinkID-Java-Sample/1.0", exchange.getRequestHeaders().getFirst("User-Agent"));
+            assertEquals("application/linkid+json, application/json, */*", exchange.getRequestHeaders().getFirst("Accept"));
+            assertEquals("ApiKey test123", exchange.getRequestHeaders().getFirst("Authorization"));
+            sendJson(exchange, 200, mapper.createObjectNode().put("ok", true));
+        });
+
+        LinkIdClient client = LinkIdClient.builder()
+            .resolverUri(baseUri)
+            .apiKey("test123")
+            .timeout(Duration.ofSeconds(2))
+            .retries(1)
+            .build();
+
+        client.resolve(linkId);
+    }
+
+    @Test
+    void error_mapping_to_specific_exceptions() throws Exception {
+        String linkId = validLinkId();
+        server.createContext("/resolve/" + linkId, exchange -> {
+            String header = Optional.ofNullable(exchange.getRequestHeaders().getFirst("X-Code")).orElse("500");
+            int code = Integer.parseInt(header);
+            ObjectNode body = mapper.createObjectNode();
+            if (code == 410) {
+                body.put("message", "withdrawn");
+                body.set("tombstone", mapper.createObjectNode().put("why", "gone"));
+            } else if (code == 404) {
+                body.put("error", "not-found");
+            } else {
+                body.put("message", "err");
+            }
+            sendJson(exchange, code, body);
+        });
+
+        LinkIdClient client = defaultClient();
+
+        assertThrows(LinkIdClient.NotFoundException.class, () -> client.resolve(linkId, withCode(404)));
+        LinkIdClient.WithdrawnException w = assertThrows(LinkIdClient.WithdrawnException.class, () -> client.resolve(linkId, withCode(410)));
+        assertEquals("gone", w.tombstone().get("why").asText());
+        assertThrows(LinkIdClient.ValidationException.class, () -> client.resolve(linkId, withCode(400)));
+        assertThrows(LinkIdClient.ValidationException.class, () -> client.resolve(linkId, withCode(422)));
+        LinkIdClient.LinkIdException e401 = assertThrows(LinkIdClient.LinkIdException.class, () -> client.resolve(linkId, withCode(401)));
+        assertEquals("UNAUTHORIZED", e401.code());
+        LinkIdClient.LinkIdException e403 = assertThrows(LinkIdClient.LinkIdException.class, () -> client.resolve(linkId, withCode(403)));
+        assertEquals("FORBIDDEN", e403.code());
+        LinkIdClient.LinkIdException e429 = assertThrows(LinkIdClient.LinkIdException.class, () -> client.resolve(linkId, withCode(429)));
+        assertEquals("RATE_LIMITED", e429.code());
+    }
+
+    @Test
+    void validation_errors_for_linkid_and_registration_target() {
+        LinkIdClient client = defaultClient();
+        assertThrows(LinkIdClient.ValidationException.class, () -> client.resolve(""));
+        assertThrows(LinkIdClient.ValidationException.class, () -> client.resolve("short"));
+        assertThrows(LinkIdClient.ValidationException.class, () -> client.resolve(" ".repeat(33)));
+
+        assertThrows(LinkIdClient.ValidationException.class, () -> LinkIdClient.RegistrationRequest.builder()
+            .targetUri("ftp://invalid")
+            .build());
+    }
+
+    @Test
+    void resolve_options_are_encoded_in_query() throws Exception {
+        String linkId = validLinkId();
+        AtomicInteger hits = new AtomicInteger();
+        server.createContext("/resolve/" + linkId, exchange -> {
+            hits.incrementAndGet();
+            String query = Optional.ofNullable(exchange.getRequestURI().getRawQuery()).orElse("");
+            assertTrue(query.contains("format=json"));
+            assertTrue(query.contains("lang=en"));
+            assertTrue(query.contains("version=2"));
+            assertTrue(query.contains("at=2024-01-01T00%3A00%3A00Z"));
+            assertTrue(query.contains("metadata=true"));
+            sendJson(exchange, 200, mapper.createObjectNode().put("ok", true));
+        });
+
+        LinkIdClient client = defaultClient();
+        LinkIdClient.ResolveOptions options = LinkIdClient.ResolveOptions.builder()
+            .format("json")
+            .language("en")
+            .version(2)
+            .timestamp("2024-01-01T00:00:00Z")
+            .metadata(true)
+            .build();
+        client.resolve(linkId, options);
+        assertEquals(1, hits.get());
+    }
+
+    private LinkIdClient.ResolveOptions withCode(int code) {
+        return LinkIdClient.ResolveOptions.builder().header("X-Code", Integer.toString(code)).build();
+    }
+
+    private LinkIdClient defaultClient() {
+        return LinkIdClient.builder()
+            .resolverUri(baseUri)
+            .timeout(Duration.ofSeconds(2))
+            .retries(1)
+            .build();
+    }
+
+    private LinkIdClient clientWithApiKey(String key) {
+        return LinkIdClient.builder()
+            .resolverUri(baseUri)
+            .apiKey(key)
+            .timeout(Duration.ofSeconds(2))
+            .retries(1)
+            .build();
+    }
+
+    private static void sendJson(HttpExchange exchange, int status, JsonNode node) throws IOException {
+        byte[] bytes = node.toString().getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    private static void sendResponse(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    private static String validLinkId() {
+        return "A".repeat(32);
+    }
+}
+
+

--- a/spec/index.html
+++ b/spec/index.html
@@ -29,7 +29,7 @@
 </head>
 <body>
   <section id="abstract">
-    <p><dfn data-lt="LinkID">LinkID</dfn> defines a persistent identifier and resolution mechanism for Web resources that remain stable even when the underlying locations change. It specifies identifier syntax, a resolver algorithm, metadata, caching semantics, and security and privacy requirements. LinkID can be expressed as an HTTP URI namespace (<code>https://w3id.org/linkid/&lt;id&gt;</code>) and, if standardized in the IETF, an optional <code>lid:</code> URI scheme.</p>
+    <p><dfn data-lt="LinkID">LinkID</dfn> defines a persistent identifier and resolution mechanism for Web resources that remain stable even when the underlying locations change. It specifies identifier syntax, a resolver algorithm, metadata, caching semantics, and security and privacy requirements. LinkID can be expressed as an HTTP URI namespace (<code>https://w3id.org/linkid/&lt;id&gt;</code>) and, if standardized in the IETF, an optional <code>linkid:</code> URI scheme.</p>
   </section>
 
   <section id="sotd">
@@ -83,17 +83,17 @@
       <h3>HTTP Form (Recommended)</h3>
       <p>A LinkID is represented as an HTTPS URI under a persistent namespace, e.g.,</p>
       <pre><code>https://w3id.org/linkid/{id}
-https://example.org/lid/{id}</code></pre>
+https://example.org/linkid/{id}</code></pre>
       <p>where <code>{id}</code> is a case‑insensitive, URL‑safe string of 32–64 characters, typically a UUID (lowercase, no dashes), a cryptographic hash, or a registry‑assigned opaque identifier.</p>
       <p>Resolvers SHOULD publish <code>/.well-known/linkid</code> to declare their resolution base and keys. The canonical JSON representation of a LinkID uses media type <code>application/linkid+json</code> (see “IANA Considerations”).</p>
     </section>
     <section>
-      <h3>Optional <code>lid:</code> Scheme</h3>
+      <h3>Optional <code>linkid:</code> Scheme</h3>
       <p>If standardized via IETF and registered with IANA, LinkID MAY be expressed as:</p>
-      <pre><code>lid:{id}
-lid:{id}?q=...
+      <pre><code>linkid:{id}
+linkid:{id}?q=...
 </code></pre>
-      <p>where URI scheme conformance and percent‑encoding follow <a data-cite="RFC3986">RFC 3986</a>. A <code>lid:</code> URI resolves via <a>LinkID Resolution</a> using a discovery step (e.g., well‑known, HTTPS bootstrap, or DNS SRV). If the <code>lid:</code> scheme proceeds, an IANA URI Scheme registration is REQUIRED (see “IANA Considerations”).</p>
+      <p>where URI scheme conformance and percent‑encoding follow <a data-cite="RFC3986">RFC 3986</a>. A <code>linkid:</code> URI resolves via <a>LinkID Resolution</a> using a discovery step (e.g., well‑known, HTTPS bootstrap, or DNS SRV). If the <code>linkid:</code> scheme proceeds, an IANA URI Scheme registration is REQUIRED (see “IANA Considerations”).</p>
       <div class="issue">Open: finalize <code>{id}</code> length/charset and collision‑resistance requirements; align with URI scheme registration if pursued.</div>
     </section>
   </section>
@@ -156,7 +156,7 @@ lid:{id}?q=...
 Result: A redirect to the best current resource, or a JSON description
 
 1. Normalize L
-   1.1 If L is in lid: form, bootstrap to an HTTPS resolver endpoint E via:
+   1.1 If L is in linkid: form, bootstrap to an HTTPS resolver endpoint E via:
        a) well‑known: https://{authority}/.well-known/linkid
        b) or static mapping table maintained by the client (MUST be updateable)
        c) or DNS discovery (e.g., _linkid._tcp)
@@ -365,7 +365,7 @@ Content-Type: application/problem+json
     <ul>
       <li><strong>Media Type:</strong> Register <code>application/linkid+json</code> under the IANA Media Types registry. Security considerations: documents may be signed; do not assume confidentiality.</li>
       <li><strong>Well‑Known URI:</strong> Register <code>linkid</code> in the Well-Known URI registry (<a data-cite="RFC8615">RFC&nbsp;8615</a>) pointing to a JSON document describing resolver capabilities.</li>
-      <li><strong>URI Scheme (Optional):</strong> If pursued, register <code>lid</code> in the URI Schemes registry with resolution via HTTPS bootstrap.</li>
+      <li><strong>URI Scheme (Optional):</strong> If pursued, register <code>linkid</code> in the URI Schemes registry with resolution via HTTPS bootstrap.</li>
       <li><strong>Problem Types:</strong> Optionally register <code>https://linkid.org/problems/*</code> identifiers for common error conditions.</li>
     </ul>
   </section>
@@ -456,8 +456,8 @@ Content-Type: application/problem+json
 https://w3id.org/linkid/b2f6f0d7c7d34e3e8a4f0a6b2a9c9f14
 → 308 Permanent Redirect → https://content.example.org/v/3/paper.pdf
 
-// lid: form (if registered)
-lid:b2f6f0d7c7d34e3e8a4f0a6b2a9c9f14
+// linkid: form (if registered)
+linkid:b2f6f0d7c7d34e3e8a4f0a6b2a9c9f14
 → discover resolver → redirect
 
 // JSON resolution
@@ -473,6 +473,7 @@ Accept: application/linkid+json
     <ul>
       <li>2025‑09‑16: Initial Editor’s Draft skeleton with normative resolution algorithm.</li>
       <li>2025‑10‑07: Expanded standardization details, extended HTTP API + webhooks, repository/tracking integration, and examples.</li>
+      <li>2025‑10‑16: Rename proposed URI scheme from <code>lid:</code> to <code>linkid:</code> to avoid IANA collision.</li>
     </ul>
   </section>
 </body>

--- a/spec/patent-alignment.html
+++ b/spec/patent-alignment.html
@@ -72,7 +72,7 @@
     <h2>Identifier Forms</h2>
     <ul>
       <li><strong>HTTP form (recommended):</strong> <code>https://w3id.org/linkid/{id}</code> or an issuer‑scoped base. See <a href="index.html#identifier-syntax">Identifier Syntax</a>.</li>
-      <li><strong>Optional <code>lid:</code> scheme:</strong> If standardized via IETF, <code>lid:{id}</code> resolves via HTTPS bootstrap. The main spec documents this as optional and non‑blocking.</li>
+      <li><strong>Optional <code>linkid:</code> scheme:</strong> If standardized via IETF, <code>linkid:{id}</code> resolves via HTTPS bootstrap. The main spec documents this as optional and non‑blocking.</li>
     </ul>
   </section>
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -176,7 +176,7 @@ The test suite validates compliance with:
 - **RFC 3986**: URI Generic Syntax
 - **RFC 7595**: URI Scheme Registration
 - **W3C LinkID Specification**: Core specification
-- **IETF Internet-Draft**: lid: URI scheme
+- **IETF Internet-Draft**: linkid: URI scheme
 
 ### Compliance Report
 Run `npm run test:compliance` to generate a detailed compliance report showing which requirements are tested and validated.


### PR DESCRIPTION
Implemented improvements:

- Add JUnit 5 (API/Engine) and Mockito test dependencies to SDK Java pom.
- Configure Maven Surefire plugin for JUnit 5 test execution.
- Introduce comprehensive `LinkIdClientTest` using embedded `HttpServer`.
- Test resolve redirect handling: `Location`, quality header, resolver header.
- Test resolve metadata (200) path: payload parsing and resolver header.
- Validate caching behavior: first fetch vs cached result (cached flag).
- Verify `register` POST body serialization and JSON response handling.
- Ensure `update`/`withdraw` clear cache and subsequent resolve re-fetches.
- Assert headers sent: `User-Agent`, `Accept`, `Authorization` (ApiKey).
- Map error codes to exceptions, validate inputs, and query via `ResolveOptions`.